### PR TITLE
Add support for Internet Explorer 9 and 10

### DIFF
--- a/src/dropin.js
+++ b/src/dropin.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var MainView = require('./views/main-view');
+var atob = require('./lib/polyfill').atob;
 var constants = require('./constants');
 var DropinModel = require('./dropin-model');
 var EventEmitter = require('./lib/event-emitter');

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -32,7 +32,7 @@
   </div>
 
   <div data-braintree-id="alert-container" class="braintree-dropin__alert-container">
-    <div data-braintree-id="alert" class="braintree-dropin__display--none"></div>
+    <div data-braintree-id="alert" class="braintree-dropin__alert braintree-dropin__display--none"></div>
   </div>
 
   <div class="braintree-dropin__sheet-area">

--- a/src/html/payment-method.html
+++ b/src/html/payment-method.html
@@ -1,5 +1,5 @@
 <div class="braintree-dropin__payment-method">
-  <svg height="28" width="48" class="braintree-dropin__icon-card">
+  <svg height="28" width="48" class="braintree-dropin__icon-card braintree-dropin__icon-card--center">
     <use xlink:href="#@ICON"></use>
   </svg>
   <dl class="braintree-dropin__list-definition">

--- a/src/lib/supports-flexbox.js
+++ b/src/lib/supports-flexbox.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function () {
+  var el = document.createElement('div');
+  var prop = 'flex-basis: 1px';
+  var prefixes = [
+    '-webkit-',
+    '-moz-',
+    '-ms-',
+    '-o-',
+    ''
+  ];
+
+  prefixes.forEach(function (prefix) {
+    el.style.cssText += prefix + prop;
+  });
+
+  return Boolean(el.style.length);
+};

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -1,50 +1,50 @@
 .braintree-dropin__form {
-    display: block;
-    margin: 0;
-    padding: 0;
+  display: block;
+  margin: 0;
+  padding: 0;
 }
 
 .braintree-dropin__form-card-field {
-    border: 0;
-    margin: 0 0 16px;
-    padding: 0;
+  border: 0;
+  margin: 0 0 16px;
+  padding: 0;
 }
 
 .braintree-dropin__form-label {
-    line-height: 1.4;
-    display: block;
-    font-size: $type-16;
-    color: $black;
-    margin: 0;
-    padding: 0;
+  line-height: 1.4;
+  display: block;
+  font-size: $type-16;
+  color: $black;
+  margin: 0;
+  padding: 0;
 }
 
 .braintree-dropin__form-label--relative {
-    position: relative;
+  position: relative;
 }
 
 .braintree-dropin__form-inline-error {
-    color: $red;
-    margin: 0;
-    padding: 0;
-    line-height: 1.4;
+  color: $red;
+  margin: 0;
+  padding: 0;
+  line-height: 1.4;
 }
 
 .braintree-dropin__form-fields {
-    margin: 4px 0 0;
-    padding: 0px 8px 0px 8px;
-    border: 1px solid $black-75;
+  margin: 4px 0 0;
+  padding: 0px 8px 0px 8px;
+  border: 1px solid $black-75;
 }
 
 .braintree-dropin__form-fields--hosted {
-    height: 44px;
+  height: 44px;
 }
 
 .braintree-dropin__form-icon--absolute {
-    position: absolute;
-    bottom: 5px;
-    right: 5px;
-    transition: opacity $time-faster linear;
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  transition: opacity $time-faster linear;
 }
 
 .braintree-dropin__form-button {
@@ -67,5 +67,5 @@
 }
 
 @include placeholder {
-    color: $black-75;
+  color: $black-75;
 }

--- a/src/scss/_ie.scss
+++ b/src/scss/_ie.scss
@@ -1,63 +1,86 @@
-.browser-upgrade {
-    font-size: 16px;
-    line-height: 1.4;
-    font-family: sans-serif;
-}
-.ieno-flexbox {
-    .braintree-card-logos__group {
-        display: block;
-        text-align: center;
-        .braintree-icon--card {
-            float: none;
-            margin-top: 0;
-        }
-    }
-    .braintree-card-logos__group:after {
-        content: "";
-        display: table;
-        clear: both;
-    }
-    img {
-        border: 0;
-    }
-    .braintree-dropdown__default {
-        display: block;
-        padding-top: 16px;
-    }
-    .braintree-dropdown__default:after {
-        content: "";
-        display: table;
-        clear: both;
-    }
-    .braintree-icon--card {
-        float: left;
-        margin-top: 10px;
-    }
-    .braintree-list--definition {
-        padding-top: 0;
-        float: left;
-    }
-    .braintree-icon--arrow,
-    .braintree-icon--check {
-        float: right;
-        margin-top: 10px;
-    }
-    .braintree-dropdown__option {
-        display: block;
-        padding-top: 16px;
-        clear: both;
-        text-decoration: none;
-    }
-    .braintree-dropdown__option:after {
-        content: "";
-        display: table;
-        clear: both;
-    }
-    .braintree-dropdown__label {
-        float: left;
-        padding-top: 10px;
-    }
-    .braintree-dropdown__image {
-        float: left;
-    }
+.braintree-dropin__no-flexbox {
+  .braintree-dropin__picker-view {
+    display: block;
+  }
+
+  [data-braintree-id="disclosure-arrow"] {
+    display: block;
+    margin-top: -10px;
+    position: absolute;
+    right: 20px;
+    top: 50%;
+  }
+
+  [data-braintree-id="card-picker-icons"] {
+    display: block;
+  }
+
+  .braintree-dropin__icon-card {
+    float: left;
+    padding-top: 0;
+  }
+
+  .braintree-dropin__icon-card--center {
+    left: 14px;
+    margin-top: -14px;
+    position: absolute;
+    top: 50%;
+  }
+
+  .braintree-dropin__check-container {
+    float: right;
+    margin-top: -9px;
+    padding-top: 0;
+    position: absolute;
+    right: 18px;
+    top: 50%;
+  }
+
+  .braintree-dropin__picker-view {
+    position: relative;
+    text-align: center;
+  }
+
+  .braintree-dropin__completed-picker-view {
+    text-align: left;
+  }
+
+  .braintree-dropin__picker-label {
+    float: left;
+    left: 18px;
+    margin-top: -11px;
+    position: absolute;
+    top: 50%;
+  }
+
+  .braintree-dropin__payment-method {
+    clear: both;
+  }
+
+  .braintree-dropin__payment-method:after {
+    clear: both;
+    content: ".";
+    display: block;
+    height: 0;
+    visibility: hidden;
+  }
+
+  .braintree-dropin__list-definition {
+    float: left;
+    margin-left: 48px;
+    padding-top: 0;
+    width: 80%;
+  }
+
+  .braintree-dropin__loading-indicator {
+    margin: 0 auto;
+  }
+
+  .braintree-dropin__form-icon--absolute {
+    float: right;
+    margin-top: -1px;
+    position: absolute;
+    right: 9px;
+    top: 50%;
+  }
 }

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -5,6 +5,7 @@ var classlist = require('../lib/classlist');
 var errors = require('../errors');
 var PaymentMethodPickerView = require('./payment-method-picker-view');
 var PayWithCardView = require('./pay-with-card-view');
+var supportsFlexbox = require('../lib/supports-flexbox');
 
 function MainView() {
   BaseView.apply(this, arguments);
@@ -43,6 +44,7 @@ MainView.prototype._initialize = function () {
   this.loadingContainer = this.element.querySelector('[data-braintree-id="loading-container"]');
   this.loadingIndicator = this.element.querySelector('[data-braintree-id="loading-indicator"]');
   this.dropinContainer = this.element.querySelector('.braintree-dropin');
+  this.supportsFlexbox = supportsFlexbox();
 
   this.model.on('asyncDependenciesReady', this.hideLoadingIndicator.bind(this));
 
@@ -75,6 +77,11 @@ MainView.prototype.addView = function (view) {
 
 MainView.prototype.setActiveView = function (id) {
   this.dropinWrapper.className = 'braintree-dropin__' + id;
+
+  if (!this.supportsFlexbox) {
+    this.dropinWrapper.className += ' braintree-dropin__no-flexbox';
+  }
+
   this.model.clearError();
 
   if (id !== 'active-payment-method') {

--- a/test/lib/unit/supports-flexbox.js
+++ b/test/lib/unit/supports-flexbox.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var supportsFlexbox = require('../../../src/lib/supports-flexbox');
+
+describe('supportsFlexbox', function () {
+  beforeEach(function () {
+    this.fakeDiv = {
+      style: {
+        cssText: '',
+        length: 0
+      }
+    };
+  });
+
+  it('returns true in PhantomJS', function () {
+    expect(supportsFlexbox()).to.equal(true);
+  });
+
+  it("returns false for browsers that don't support flexbox", function () {
+    this.sandbox.stub(document, 'createElement').returns(this.fakeDiv);
+
+    expect(supportsFlexbox()).to.equal(false);
+  });
+
+  it('returns true if the browser supports flexbox', function () {
+    this.sandbox.stub(document, 'createElement').returns(this.fakeDiv);
+
+    this.fakeDiv.style.length = 1;
+
+    expect(supportsFlexbox()).to.equal(true);
+  });
+});

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -202,6 +202,22 @@ describe('MainView', function () {
 
       expect(DropinModel.prototype.clearError).to.have.been.calledOnce;
     });
+
+    it('applies no-flexbox class when flexbox is not supported', function () {
+      this.context.supportsFlexbox = false;
+
+      MainView.prototype.setActiveView.call(this.context, 'active-payment-method');
+
+      expect(this.context.dropinWrapper.classList.contains('braintree-dropin__no-flexbox')).to.be.true;
+    });
+
+    it('does not apply no-flexbox class when flexbox is supported', function () {
+      this.context.supportsFlexbox = true;
+
+      MainView.prototype.setActiveView.call(this.context, 'active-payment-method');
+
+      expect(this.context.dropinWrapper.classList.contains('braintree-dropin__no-flexbox')).to.be.false;
+    });
   });
 
   describe('showAlert', function () {


### PR DESCRIPTION
This adds a polyfill for `atob` which is not supported in IE 9 and adds a `no-flexbox` class to make up for the lack of flexbox in IEs 9 & 10.
