### PR TITLE
Change dropdown behavior on guest checkout

### DIFF
--- a/src/html/main.html
+++ b/src/html/main.html
@@ -26,7 +26,7 @@
     <div data-braintree-id="drawer" class="braintree-dropin__drawer">
       <h2 data-braintree-id="saved-payment-methods-header" class="braintree-dropin__drawer-header braintree-dropin__display--none">Saved Payment Methods</h2>
       <ul data-braintree-id="saved-payment-methods" class="braintree-dropin__drawer-list"></ul>
-      <h2 class="braintree-dropin__drawer-header">Add A Payment Method</h2>
+      <h2 data-braintree-id="add-payment-method-header" class="braintree-dropin__drawer-header">Add A Payment Method</h2>
       <ul data-braintree-id="enabled-payment-methods" class="braintree-dropin__drawer-list"></ul>
     </div>
   </div>

--- a/src/lib/is-guest-checkout.js
+++ b/src/lib/is-guest-checkout.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var atob = require('./polyfill').atob;
+
+function isTokenizationKey(str) {
+  return /^[a-zA-Z0-9]+_[a-zA-Z0-9]+_[a-zA-Z0-9_]+$/.test(str);
+}
+
+module.exports = function (authorization) {
+  var authorizationFingerprint;
+
+  if (!isTokenizationKey(authorization)) {
+    authorizationFingerprint = JSON.parse(atob(authorization)).authorizationFingerprint;
+    return !authorizationFingerprint || authorizationFingerprint.indexOf('customer_id=') === -1;
+  }
+  return true;
+};

--- a/src/views/payment-method-picker-view.js
+++ b/src/views/payment-method-picker-view.js
@@ -2,9 +2,10 @@
 
 var BaseView = require('./base-view');
 var CardPickerView = require('./picker-views/card-picker-view');
-var CompletedPickerView = require('./picker-views/completed-picker-view');
-var PayPalPickerView = require('./picker-views/paypal-picker-view');
 var classlist = require('../lib/classlist');
+var CompletedPickerView = require('./picker-views/completed-picker-view');
+var isGuestCheckout = require('../lib/is-guest-checkout');
+var PayPalPickerView = require('./picker-views/paypal-picker-view');
 
 function PaymentMethodPickerView() {
   BaseView.apply(this, arguments);
@@ -19,7 +20,10 @@ PaymentMethodPickerView.ID = PaymentMethodPickerView.prototype.ID = 'payment-met
 PaymentMethodPickerView.prototype._initialize = function () {
   var enabledPaymentMethods = this.getElementById('enabled-payment-methods');
   var savedPaymentMethodsHeader = this.getElementById('saved-payment-methods-header');
+  var addPaymentMethodHeader = this.getElementById('add-payment-method-header');
   var paymentMethods = this.model.getPaymentMethods();
+
+  this.isGuestCheckout = isGuestCheckout(this.options.authorization);
 
   this.element.addEventListener('click', function () {
     this.toggleDrawer();
@@ -29,6 +33,13 @@ PaymentMethodPickerView.prototype._initialize = function () {
   this.savedPaymentMethods = this.getElementById('saved-payment-methods');
   this.activePaymentMethod = this.getElementById('active-payment-method');
   this.choosePaymentMethod = this.getElementById('choose-payment-method');
+
+  if (this.isGuestCheckout) {
+    classlist.add(this.savedPaymentMethods, 'braintree-dropin__display--none');
+    classlist.add(savedPaymentMethodsHeader, 'braintree-dropin__display--none');
+
+    addPaymentMethodHeader.innerHTML = 'Change Payment Method';
+  }
 
   this.views = [
     CardPickerView,
@@ -62,7 +73,9 @@ PaymentMethodPickerView.prototype._initialize = function () {
   }.bind(this));
 
   this.model.on('addPaymentMethod', function (paymentMethod) {
-    classlist.remove(savedPaymentMethodsHeader, 'braintree-dropin__display--none');
+    if (!this.isGuestCheckout) {
+      classlist.remove(savedPaymentMethodsHeader, 'braintree-dropin__display--none');
+    }
     classlist.remove(this.element, 'braintree-dropin__hide');
     this.addCompletedPickerView(paymentMethod);
   }.bind(this));

--- a/test/lib/unit/is-guest-checkout.js
+++ b/test/lib/unit/is-guest-checkout.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var fake = require('../../helpers/fake');
+var isGuestCheckout = require('../../../src/lib/is-guest-checkout');
+
+describe('isGuestCheckout', function () {
+  it('returns true when given a tokenization key', function () {
+    var auth = 'fake_tokenization_key';
+
+    expect(isGuestCheckout(auth)).to.be.true;
+  });
+
+  it('returns true when given a client token without a customer ID', function () {
+    var auth = fake.clientToken;
+
+    expect(isGuestCheckout(auth)).to.be.true;
+  });
+
+  it('returns false when given a client token with a customer ID', function () {
+    var fakeClientToken = fake.configuration().gatewayConfiguration;
+
+    fakeClientToken.authorizationFingerprint = 'auth_fingerprint&customer_id=abc123';
+    fakeClientToken = btoa(JSON.stringify(fakeClientToken));
+
+    expect(isGuestCheckout(fakeClientToken)).to.be.false;
+  });
+});


### PR DESCRIPTION
If you have a customer ID, you'll see this:

![screenshot](https://cloud.githubusercontent.com/assets/777712/19165338/3a805fa0-8bb8-11e6-8bf4-761384ed0a72.png)

Now, if you _don't_ have a customer ID (AKA guest checkout), you'll see this:

![screenshot](https://cloud.githubusercontent.com/assets/777712/19165374/62122f30-8bb8-11e6-8324-72493f533979.png)

The "saved payment methods" are gone and the text for adding a new payment method have changed.
