### PR TITLE
Update braintree-web to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.3.0"
+    "braintree-web": "3.5.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
`npm test` passes after this change.
