### PR TITLE
Update phantomjs-prebuilt to 2.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "karma-phantomjs-launcher": "1.0.0",
     "mocha": "3.0.0",
     "packageify": "0.2.3",
-    "phantomjs-prebuilt": "2.1.7",
+    "phantomjs-prebuilt": "2.1.13",
     "run-sequence": "1.2.2",
     "sinon": "1.17.4",
     "sinon-chai": "2.8.0",


### PR DESCRIPTION
This is the latest version.

Nothing in [the release notes](https://github.com/Medium/phantomjs/releases) makes this look like it'll cause problems. Version 2.1.9 says that it  "bundles the dependencies, for more robust npm installs"—this piqued my interest.

`npm test` passes after this change.
