### PR TITLE
Move lib tests from test/lib to test/unit/lib

### DIFF
--- a/test/unit/lib/unit/assign.js
+++ b/test/unit/lib/unit/assign.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assignModule = require('../../../src/lib/assign');
+var assignModule = require('../../../../src/lib/assign');
 
 describe('assign', function () {
   describe('exported function', function () {

--- a/test/unit/lib/unit/classlist.js
+++ b/test/unit/lib/unit/classlist.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var classlist = require('../../../src/lib/classlist');
+var classlist = require('../../../../src/lib/classlist');
 
 describe('classlist', function () {
   beforeEach(function () {

--- a/test/unit/lib/unit/enumerate.js
+++ b/test/unit/lib/unit/enumerate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var enumerate = require('../../../src/lib/enumerate');
+var enumerate = require('../../../../src/lib/enumerate');
 
 describe('enumerate', function () {
   it('sets keys equal to their values', function () {

--- a/test/unit/lib/unit/event-emitter.js
+++ b/test/unit/lib/unit/event-emitter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var EventEmitter = require('../../../src/lib/event-emitter');
+var EventEmitter = require('../../../../src/lib/event-emitter');
 
 describe('EventEmitter', function () {
   it('can emit when no one is listening', function () {

--- a/test/unit/lib/unit/hide-unsupported-card-icons.js
+++ b/test/unit/lib/unit/hide-unsupported-card-icons.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var cardIcons = require('../../../src/html/card-icons.html');
-var hideUnsupportedCardIcons = require('../../../src/lib/hide-unsupported-card-icons');
+var cardIcons = require('../../../../src/html/card-icons.html');
+var hideUnsupportedCardIcons = require('../../../../src/lib/hide-unsupported-card-icons');
 
 describe('hideUnsupportedCardIcons', function () {
   beforeEach(function () {

--- a/test/unit/lib/unit/is-guest-checkout.js
+++ b/test/unit/lib/unit/is-guest-checkout.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var fake = require('../../helpers/fake');
-var isGuestCheckout = require('../../../src/lib/is-guest-checkout');
+var fake = require('../../../helpers/fake');
+var isGuestCheckout = require('../../../../src/lib/is-guest-checkout');
 
 describe('isGuestCheckout', function () {
   it('returns true when given a tokenization key', function () {

--- a/test/unit/lib/unit/polyfill.js
+++ b/test/unit/lib/unit/polyfill.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var atob = require('../../../src/lib/polyfill')._atob;
+var atob = require('../../../../src/lib/polyfill')._atob;
 
 describe('Polyfill', function () {
   describe('atob', function () {

--- a/test/unit/lib/unit/supports-flexbox.js
+++ b/test/unit/lib/unit/supports-flexbox.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var supportsFlexbox = require('../../../src/lib/supports-flexbox');
+var supportsFlexbox = require('../../../../src/lib/supports-flexbox');
 
 describe('supportsFlexbox', function () {
   beforeEach(function () {

--- a/test/unit/lib/unit/uuid.js
+++ b/test/unit/lib/unit/uuid.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('../../../src/lib/uuid');
+var uuid = require('../../../../src/lib/uuid');
 var isUuid = require('is-uuid');
 
 describe('uuid', function () {


### PR DESCRIPTION
Thought it was a little weird for `lib` tests to be in `test/lib` and not `test/unit/lib`. Lemme know if my curiosity was wrong!

`npm test` passes after this change. I also made sure that the lib tests ran.
