### PR TITLE
Minor: fix inconsistent indentation in SCSS files

### DIFF
--- a/src/scss/_alerts.scss
+++ b/src/scss/_alerts.scss
@@ -11,5 +11,5 @@
 }
 
 .braintree-dropin__alert-link {
-    color: $red;
+  color: $red;
 }

--- a/src/scss/_credit-card.scss
+++ b/src/scss/_credit-card.scss
@@ -1,5 +1,5 @@
 .braintree-hosted-fields-focused {
-    background: $black-98;
+  background: $black-98;
 }
 .braintree-hosted-fields-invalid {
   -webkit-touch-callout: none; /* iOS Safari */

--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -1,5 +1,5 @@
 .braintree-dropin__form {
-    display: block;
+  display: block;
   margin: 0;
   padding: 0;
 }

--- a/src/scss/_list.scss
+++ b/src/scss/_list.scss
@@ -1,24 +1,24 @@
 .braintree-dropin__list-definition {
-    line-height: 1.4;
-    flex-grow: 2;
-    margin: 0;
-    padding: 4px 12px;
+  line-height: 1.4;
+  flex-grow: 2;
+  margin: 0;
+  padding: 4px 12px;
 }
 
 .braintree-dropin__list-term {
-    line-height: 1.4;
-    font-size: $type-16;
-    font-weight: 600;
-    margin: 0 0 3px;
-    padding: 0;
-    color: $black;
+  line-height: 1.4;
+  font-size: $type-16;
+  font-weight: 600;
+  margin: 0 0 3px;
+  padding: 0;
+  color: $black;
 }
 
 .braintree-dropin__list-desc {
-    line-height: 1.4;
-    color: $black-40;
-    font-size: $type-14;
-    margin: 0;
-    padding: 0;
+  line-height: 1.4;
+  color: $black-40;
+  font-size: $type-14;
+  margin: 0;
+  padding: 0;
 }
 

--- a/src/scss/_media-queries.scss
+++ b/src/scss/_media-queries.scss
@@ -1,14 +1,14 @@
 @media (max-width: 620px) {
-    .braintree-dropin__form-label {
-        font-size: $type-14;
-    }
-    .braintree-dropin__picker-view {
-        justify-content: space-between;
-    }
-    .image--PayPal-button {
-        width: 140px;
-    }
-    .braintree-dropin__image {
-        text-align: right;
-    }
+  .braintree-dropin__form-label {
+    font-size: $type-14;
+  }
+  .braintree-dropin__picker-view {
+    justify-content: space-between;
+  }
+  .image--PayPal-button {
+    width: 140px;
+  }
+  .braintree-dropin__image {
+    text-align: right;
+  }
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,14 +1,14 @@
 @mixin placeholder {
-    ::-webkit-input-placeholder {
-        @content
-    }
-    :-moz-placeholder {
-        @content
-    }
-    ::-moz-placeholder {
-        @content
-    }
-    :-ms-input-placeholder {
-        @content
-    }
+  ::-webkit-input-placeholder {
+    @content
+  }
+  :-moz-placeholder {
+    @content
+  }
+  ::-moz-placeholder {
+    @content
+  }
+  :-ms-input-placeholder {
+    @content
+  }
 }

--- a/src/scss/_tools.scss
+++ b/src/scss/_tools.scss
@@ -1,12 +1,12 @@
 .braintree-dropin__desaturate {
-    opacity: 0.6;
-    transition: filter $time-faster;
-    -webkit-filter: grayscale(1);
-    /* Google Chrome, Safari 6+ & Opera 15+ */
-    filter: gray;
-    /* IE6-9 */
-    filter: grayscale(1);
-    /* Microsoft Edge and Firefox 35+ */
+  opacity: 0.6;
+  transition: filter $time-faster;
+  -webkit-filter: grayscale(1);
+  /* Google Chrome, Safari 6+ & Opera 15+ */
+  filter: gray;
+  /* IE6-9 */
+  filter: grayscale(1);
+  /* Microsoft Edge and Firefox 35+ */
 }
 
 .braintree-dropin__display--none {


### PR DESCRIPTION
Some lines were indented with 4 spaces instead of the usual 2.

`npm run build` and `npm test` work fine after this change.

I'll merge this after one 👍 because it's so minor.
