### PR TITLE
Model should always be instantiated with an array of payment methods

### DIFF
--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -5,7 +5,7 @@ var paymentOptionIDs = require('./constants').paymentOptionIDs;
 var isGuestCheckout = require('./lib/is-guest-checkout');
 
 function DropinModel(options) {
-  this._paymentMethods = options && options.paymentMethods ? options.paymentMethods : [];
+  this._paymentMethods = options.paymentMethods;
   this.dependenciesInitializing = 0;
   this.isGuestCheckout = isGuestCheckout(options.merchantConfiguration.authorization);
 

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -125,7 +125,7 @@ Dropin.prototype._injectStylesheet = function () {
 
 Dropin.prototype._getVaultedPaymentMethods = function (callback) {
   if (isGuestCheckout(this._merchantConfiguration.authorization)) {
-    callback();
+    callback([]);
   } else {
     this._client.request({
       endpoint: 'payment_methods',
@@ -136,9 +136,12 @@ Dropin.prototype._getVaultedPaymentMethods = function (callback) {
     }, function (err, paymentMethodsPayload) {
       var paymentMethods;
 
-      if (!err) {
+      if (err) {
+        paymentMethods = [];
+      } else {
         paymentMethods = paymentMethodsPayload.paymentMethods.map(formatPaymentMethodPayload);
       }
+
       callback(paymentMethods);
     });
   }

--- a/test/helpers/fake.js
+++ b/test/helpers/fake.js
@@ -67,7 +67,8 @@ function modelOptions() {
     },
     merchantConfiguration: {
       authorization: clientToken
-    }
+    },
+    paymentMethods: []
   };
 }
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -16,7 +16,8 @@ describe('DropinModel', function () {
       },
       merchantConfiguration: {
         authorization: fake.clientToken
-      }
+      },
+      paymentMethods: []
     };
   });
 
@@ -36,7 +37,7 @@ describe('DropinModel', function () {
         expect(model._paymentMethods).to.deep.equal(['foo']);
       });
 
-      it('_paymentMethods is null if no existing payment methods', function () {
+      it('_paymentMethods is empty if no existing payment methods', function () {
         var model = new DropinModel(this.modelOptions);
 
         expect(model._paymentMethods).to.deep.equal([]);


### PR DESCRIPTION
We should always instantiate `DropinModel` with an array of payment methods, even if it's an empty array.