### PR TITLE
Minor: use `classlist.toggle` to shorten some code a bit

### DIFF
--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -42,11 +42,7 @@ PaymentMethodView.prototype._initialize = function () {
 };
 
 PaymentMethodView.prototype.setActive = function (isActive) {
-  if (isActive) {
-    classlist.add(this.element, 'braintree-method--active');
-    return;
-  }
-  classlist.remove(this.element, 'braintree-method--active');
+  classlist.toggle(this.element, 'braintree-method--active', isActive);
 };
 
 module.exports = PaymentMethodView;

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -83,12 +83,32 @@ describe('PaymentMethodView', function () {
     });
 
     it('adds braintree-method--active if setting active payment method', function () {
+      this.context.element.className = '';
+
+      PaymentMethodView.prototype.setActive.call(this.context, true);
+
+      expect(this.context.element.classList.contains('braintree-method--active')).to.be.true;
+    });
+
+    it("doesn't change the class if braintree-method--active is already there", function () {
+      this.context.element.className = 'braintree-method--active';
+
       PaymentMethodView.prototype.setActive.call(this.context, true);
 
       expect(this.context.element.classList.contains('braintree-method--active')).to.be.true;
     });
 
     it('removes braintree-method--active if setting active payment method', function () {
+      this.context.element.className = 'braintree-method--active';
+
+      PaymentMethodView.prototype.setActive.call(this.context, false);
+
+      expect(this.context.element.classList.contains('braintree-method--active')).to.be.false;
+    });
+
+    it("doesn't remove the class if it wasn't there", function () {
+      this.context.element.className = '';
+
       PaymentMethodView.prototype.setActive.call(this.context, false);
 
       expect(this.context.element.classList.contains('braintree-method--active')).to.be.false;


### PR DESCRIPTION
This used to do something like:

    if (isActive) {
      classlist.add(/* ... */)
    } else {
      classlist.remove(/* ... */)
    }

And now does something like:

    classlist.throttle(/* ... */, isActive)

I also added a few more tests to be sure things were working.