### PR TITLE
Keep field-secondary-icon visible when card type is known

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -192,10 +192,6 @@ $curve-springy: cubic-bezier(0.43, 0.48, 0.62, 1.07);
   .braintree-sheet__card-icon {
     display: inline-block;
     padding-left: 5px;
-
-    &.braintree-hidden {
-      display: none;
-    }
   }
 
   .braintree-sheet__text {
@@ -272,11 +268,13 @@ $curve-springy: cubic-bezier(0.43, 0.48, 0.62, 1.07);
     .braintree-form__field-error-icon,
     .braintree-form__field-secondary-icon,
     &.braintree-form__field-group--has-error .braintree-form__field-secondary-icon,
+    &.braintree-form__field-group--has-error.braintree-form__field-group--card-type-known .braintree-form__field-secondary-icon,
     &.braintree-form__field-group--has-error.braintree-form__field-group--is-focused .braintree-form__field-secondary-icon {
       display: none;
     }
 
     &.braintree-form__field-group--has-error .braintree-form__field-error-icon,
+    &.braintree-form__field-group--card-type-known .braintree-form__field-secondary-icon,
     &.braintree-form__field-group--is-focused .braintree-form__field-secondary-icon {
       display: block;
     }

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -214,6 +214,7 @@ CardView.prototype._onCardTypeChangeEvent = function (event) {
   var cvvHrefLink = '#iconCVVBack';
   var cvvDescriptor = '(3 digits)';
   var cvvPlaceholder = '•••';
+  var numberFieldGroup = this.getElementById('number-field-group');
 
   if (event.cards.length === 1) {
     cardType = event.cards[0].type;
@@ -223,6 +224,10 @@ CardView.prototype._onCardTypeChangeEvent = function (event) {
       cvvDescriptor = '(4 digits)';
       cvvPlaceholder = '••••';
     }
+    // Keep icon visible when field is not focused
+    classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
+  } else {
+    classlist.remove(numberFieldGroup, 'braintree-form__field-group--card-type-known');
   }
 
   this.cardNumberIconSvg.setAttribute('xlink:href', cardNumberHrefLink);
@@ -235,12 +240,6 @@ CardView.prototype._onFocusEvent = function (event) {
   var fieldGroup = this.getElementById(camelCaseToSnakeCase(event.emittedBy) + '-field-group');
 
   classlist.add(fieldGroup, 'braintree-form__field-group--is-focused');
-
-  if (event.emittedBy === 'number') {
-    classlist.remove(this.cardNumberIcon, 'braintree-hidden');
-  } else if (event.emittedBy === 'cvv') {
-    classlist.remove(this.cvvIcon, 'braintree-hidden');
-  }
 };
 
 CardView.prototype._onNotEmptyEvent = function (event) {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -459,27 +459,6 @@ describe('CardView', function () {
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.false;
       });
 
-      it('does not hide the card number icon when the number field is blurred and not empty', function () {
-        var fakeEvent = {
-          cards: [{type: 'visa'}],
-          emittedBy: 'number',
-          fields: {
-            number: {isEmpty: false}
-          }
-        };
-        var hostedFieldsInstance = {
-          on: this.sandbox.stub().callsArgWith(1, fakeEvent)
-        };
-        var cardNumberIcon = this.element.querySelector('[data-braintree-id="card-number-icon"]');
-
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        classlist.remove(cardNumberIcon, 'braintree-hidden');
-
-        CardView.prototype._initialize.call(this.context);
-
-        expect(this.context.cardNumberIcon.classList.contains('braintree-hidden')).to.be.false;
-      });
-
       it('applies error class if field is not valid', function () {
         var fakeEvent = {
           emittedBy: 'number',
@@ -566,6 +545,61 @@ describe('CardView', function () {
     describe('onCardTypeChange event', function () {
       beforeEach(function () {
         this.context._onCardTypeChangeEvent = CardView.prototype._onCardTypeChangeEvent;
+      });
+
+      it('adds the card-type-known class when there is one possible card type', function () {
+        var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
+        var fakeEvent = {
+          cards: [{type: 'master-card'}],
+          emittedBy: 'number'
+        };
+        var hostedFieldsInstance = {
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setPlaceholder: function () {}
+        };
+
+        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        CardView.prototype._initialize.call(this.context);
+
+        expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.true;
+      });
+
+      it('removes the card-type-known class when there is no possible card type', function () {
+        var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
+        var fakeEvent = {
+          cards: [],
+          emittedBy: 'number'
+        };
+        var hostedFieldsInstance = {
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setPlaceholder: function () {}
+        };
+
+        classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
+
+        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        CardView.prototype._initialize.call(this.context);
+
+        expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
+      });
+
+      it('removes the card-type-known class when there are many possible card types', function () {
+        var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
+        var fakeEvent = {
+          cards: [{type: 'master-card'}, {type: 'foo-pay'}],
+          emittedBy: 'number'
+        };
+        var hostedFieldsInstance = {
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setPlaceholder: function () {}
+        };
+
+        classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
+
+        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        CardView.prototype._initialize.call(this.context);
+
+        expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
       });
 
       it('updates the card number icon to the card type if there is one possible card type', function () {
@@ -1155,7 +1189,7 @@ describe('CardView', function () {
       expect(this.context.hostedFieldsInstance.tokenize).to.not.be.called;
     });
 
-    it('shows invalid field error when attempting to sumbit an invalid field', function () {
+    it('shows invalid field error when attempting to submit an invalid field', function () {
       var numberFieldError = this.element.querySelector('[data-braintree-id="number-field-error"]');
 
       this.context.hostedFieldsInstance.getState.returns({


### PR DESCRIPTION
Previously, the icon (e.g. Visa icon) would disappear on blur. This adds a class called `braintree-form__field-group--card-type-known`, added when the card type is known, which shows the icon.