### PR TITLE
Fix PayPal button click event bug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Fix bug where PayPal button could not be clicked in some browsers
+
 1.0.0-beta.3
 ------------
 

--- a/src/views/payment-sheet-views/paypal-view.js
+++ b/src/views/payment-sheet-views/paypal-view.js
@@ -58,7 +58,6 @@ PayPalView.prototype._createPayPalButton = function () {
 PayPalView.prototype._tokenize = function () {
   var tokenizeReturn;
 
-  event.preventDefault();
   this._authInProgress = true;
 
   tokenizeReturn = this.paypalInstance.tokenize(this.model.merchantConfiguration.paypal, function (tokenizeErr, tokenizePayload) {
@@ -83,7 +82,8 @@ PayPalView.prototype._tokenize = function () {
   this.closeFrame = tokenizeReturn.close;
 };
 
-PayPalView.prototype._onSelect = function () {
+PayPalView.prototype._onSelect = function (event) {
+  event.preventDefault();
   if (this._authInProgress) {
     this._focusFrame();
   } else {


### PR DESCRIPTION
This fixes a bug where `event.preventDefault` was called when `event` was not properly defined.

This didn't appear in Chrome while we were developing, so we didn't catch it until we ran through some browser testing after the fact. Moving the `preventDefault` call to `_onSelect` where `event` is always defined solved the problem in all the browsers (Chrome, Firefox, Safari, Edge, mobile Safari) we tested. 