### PR TITLE
Replace remove with removeChild for browser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Fix bug where PayPal button could not be clicked in some browsers
 - Fix bug where SVGs did not render correctly in Edge
+- Fix bug in some browsers that prevented form from appearing with certain configurations
 - Use version 3.7.0 of braintree-web
 
 1.0.0-beta.3

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -17,6 +17,7 @@ CardView.prototype.constructor = CardView;
 CardView.ID = CardView.prototype.ID = constants.paymentOptionIDs.card;
 
 CardView.prototype._initialize = function () {
+  var cvvFieldGroup, postalCodeFieldGroup;
   var cardIcons = this.getElementById('card-view-icons');
   var challenges = this.client.getConfiguration().gatewayConfiguration.challenges;
   var hasCVV = challenges.indexOf('cvv') !== -1;
@@ -76,11 +77,15 @@ CardView.prototype._initialize = function () {
   this.fieldErrors = {};
 
   if (!hasCVV) {
-    this.getElementById('cvv-field-group').remove();
+    cvvFieldGroup = this.getElementById('cvv-field-group');
+
+    cvvFieldGroup.parentNode.removeChild(cvvFieldGroup);
     delete hfOptions.fields.cvv;
   }
   if (!hasPostal) {
-    this.getElementById('postal-code-field-group').remove();
+    postalCodeFieldGroup = this.getElementById('postal-code-field-group');
+
+    postalCodeFieldGroup.parentNode.removeChild(postalCodeFieldGroup);
     delete hfOptions.fields.postalCode;
   }
 


### PR DESCRIPTION
The `remove` function is not supported in Internet Explorer, so use `removeChild` instead.