### PR TITLE
Hide field clear for Edge and IE in CardView

### DIFF
--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -62,6 +62,9 @@ CardView.prototype._initialize = function () {
       },
       ':-ms-input-placeholder ': {
         color: 'rgba(0,0,0,0.25)'
+      },
+      'input::-ms-clear': {
+        color: 'white'
       }
     }
   };

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -64,7 +64,7 @@ CardView.prototype._initialize = function () {
         color: 'rgba(0,0,0,0.25)'
       },
       'input::-ms-clear': {
-        color: 'white'
+        color: 'transparent'
       }
     }
   };


### PR DESCRIPTION
### Summary
This hides the 'X' icon that interfered with the error icons in the CardView in IE and Edge.
<img width="630" alt="edge-error-styles" src="https://cloud.githubusercontent.com/assets/7514489/22835142/60ae5a28-ef7d-11e6-9926-42509a5e8603.png">


### Checklist

~Added a changelog entry~
- [x] Ran unit tests
