### PR TITLE
Transition helper

### DIFF
--- a/src/lib/browser-detection.js
+++ b/src/lib/browser-detection.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function isIe9(userAgent) {
+  userAgent = userAgent || navigator.userAgent;
+  return userAgent.indexOf('MSIE 9') !== -1;
+}
+
+module.exports = {
+  isIe9: isIe9
+};

--- a/src/lib/transition-helper.js
+++ b/src/lib/transition-helper.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var browserDetection = require('./browser-detection');
+
+function onTransitionEnd(element, callback) {
+  if (browserDetection.isIe9()) {
+    callback();
+    return;
+  }
+
+  element.addEventListener('transitionend', callback);
+}
+
+module.exports = {
+  onTransitionEnd: onTransitionEnd
+};

--- a/test/unit/lib/unit/browser-detection.js
+++ b/test/unit/lib/unit/browser-detection.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var isIe9 = require('../../../../src/lib/browser-detection').isIe9;
+
+describe('browserDetection', function () {
+  describe('isIe9', function () {
+    it('returns false for Phantom', function () {
+      expect(isIe9()).to.be.false;
+    });
+
+    it('false when chrome', function () {
+      var isChrome = isIe9('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36');
+
+      expect(isChrome).to.be.false;
+    });
+
+    it('true when IE9', function () {
+      var ua = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)';
+
+      expect(isIe9(ua)).to.be.true;
+    });
+
+    it('false when IE8', function () {
+      var ua = 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E)';
+
+      expect(isIe9(ua)).to.be.false;
+    });
+  });
+});

--- a/test/unit/lib/unit/transition-helper.js
+++ b/test/unit/lib/unit/transition-helper.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var browserDetection = require('../../../../src/lib/browser-detection');
+var onTransitionEnd = require('../../../../src/lib/transition-helper').onTransitionEnd;
+
+describe('onTransitionEnd', function () {
+  it('immediately calls callback when IE9', function (done) {
+    var element = document.createElement('div');
+
+    this.sandbox.stub(browserDetection, 'isIe9').returns(true);
+
+    onTransitionEnd(element, function () {
+      done();
+    });
+  });
+
+  it('calls callback after onTransitionEnd end', function (done) {
+    var element = document.createElement('div');
+    var eventListenerSpy = this.sandbox.spy(function (eventName, callback) {
+      if (eventName === 'transitionend') {
+        callback();
+      }
+    });
+
+    element.addEventListener = eventListenerSpy;
+
+    this.sandbox.stub(browserDetection, 'isIe9').returns(false);
+
+    onTransitionEnd(element, function () {
+      expect(eventListenerSpy).to.be.calledOnce;
+
+      done();
+    });
+  });
+});
+

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var BaseView = require('../../../../src/views/base-view');
+var CardView = require('../../../../src/views/payment-sheet-views/card-view');
 var classlist = require('../../../../src/lib/classlist');
 var DropinModel = require('../../../../src/dropin-model');
 var fake = require('../../../helpers/fake');
 var hostedFields = require('braintree-web/hosted-fields');
 var mainHTML = require('../../../../src/html/main.html');
-var CardView = require('../../../../src/views/payment-sheet-views/card-view');
 var strings = require('../../../../src/translations/en');
 
 describe('CardView', function () {


### PR DESCRIPTION
### Summary

`onTransitionEnd` will help shim transitions for IE 9. We are expecting transition end events to continue on to the next view, but since IE 9 does not support transitions we need to use the transition helper to give us a callback pattern.

Note that there is no usage of this yet, but will be used on our transition branch. 

### Checklist

- [X] Ran unit tests
