### PR TITLE
Integration test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 npm-debug.log
 
 .DS_Store
+
+.env

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--color
+--default-path spec
+--format progress
+--require spec_helper

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use ruby-2.3.0@braintree-web-drop-in --create --install

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+
+gem "rake"
+
+group :development do
+  gem "dotenv"
+  gem "capybara"
+  gem "sauce"
+  gem "sauce-connect"
+  gem "selenium-webdriver"
+  gem "rspec"
+  gem "parallel_tests"
+  gem "rspec-retry"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,103 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    capybara (2.5.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
+    cmdparse (3.0.1)
+    diff-lcs (1.2.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.1.0)
+    ffi (1.9.10)
+    highline (1.7.8)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    json (1.8.3)
+    mime-types (2.99)
+    mini_portile2 (2.0.0)
+    multi_json (1.11.2)
+    net-http-persistent (2.9.4)
+    net-ssh (3.0.2)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    netrc (0.11.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
+    parallel (1.6.1)
+    parallel_tests (1.3.7)
+      parallel
+    rack (1.6.4)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rake (10.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-retry (0.4.5)
+      rspec-core
+    rspec-support (3.4.1)
+    rubyzip (1.1.7)
+    sauce (3.5.11)
+      childprocess (>= 0.1.6)
+      cmdparse (>= 2.0.2)
+      highline (>= 1.5.0)
+      json (>= 1.2.0)
+      net-http-persistent
+      net-ssh
+      net-ssh-gateway
+      parallel_tests (>= 1.1.1, <= 1.3.7)
+      rest-client
+      sauce_whisk (~> 0.0.11)
+      selenium-webdriver (>= 0.1.2)
+    sauce-connect (3.6.2)
+      sauce (~> 3.5)
+    sauce_whisk (0.0.19)
+      json (~> 1.8.1)
+      rest-client (~> 1.8.0)
+    selenium-webdriver (2.49.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+    websocket (1.2.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  capybara
+  dotenv
+  parallel_tests
+  rake
+  rspec
+  rspec-retry
+  sauce
+  sauce-connect
+  selenium-webdriver
+
+BUNDLED WITH
+   1.11.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require "sauce"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "development": "gulp development",
     "lint": "eslint src test",
     "pretest": "npm run lint",
-    "test": "karma start test/config/karma.js --single-run"
+    "test": "karma start test/config/karma.js --single-run",
+    "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec"
   },
   "repository": {
     "type": "git",
@@ -44,6 +45,7 @@
     "packageify": "0.2.3",
     "phantomjs-prebuilt": "2.1.13",
     "run-sequence": "1.2.2",
+    "sauce-connect-launcher": "0.14.0",
     "serve-static": "1.11.1",
     "sinon": "1.17.4",
     "sinon-chai": "2.8.0",

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -1,0 +1,41 @@
+require_relative "helpers/paypal_helper"
+
+HOSTNAME = `hostname`.chomp
+PORT = 4567
+
+describe "Drop-in" do
+  include PayPal
+
+  before :each do
+    visit "http://#{HOSTNAME}:#{PORT}"
+  end
+
+  # it "tokenizes a card" do
+  #   click_on('Card')
+  #
+  #   find('label[for="credit-card-number"]').click()
+  #   find('iframe[name="braintree-hosted-field-number"]').send_keys('4111111111111111')
+  #
+  #   find('label[for="expiration"]').click()
+  #   find('iframe[name="braintree-hosted-field-expirationDate"]').send_keys('12' + (Time.new.year + 2).to_s[-2..-1])
+  #
+  #   click_button('Pay')
+  #
+  #   # Drop-in Details
+  #   expect(page).to have_content('Ending in ••11')
+  #
+  #   # Nonce Details
+  #   expect(page).to have_content('CreditCard')
+  #   expect(page).to have_content('ending in 11')
+  #   expect(page).to have_content('Visa')
+  # end
+
+  it "tokenizes PayPal" do
+    find(".braintree-option__label", :text => "PayPal").click
+
+    open_popup_and_complete_login
+
+    expect(page).to have_content('bt_buyer_us@paypal.com')
+  end
+
+end

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -1,42 +1,43 @@
 require_relative "helpers/paypal_helper"
+require_relative "helpers/drop_in_helper"
 
 HOSTNAME = `hostname`.chomp
 PORT = 4567
 
 describe "Drop-in" do
   include PayPal
+  include DropIn
 
   before :each do
     visit "http://#{HOSTNAME}:#{PORT}"
   end
 
-  # TODO: Figure out how to focus to Hosted Fields in Drop-in.
-  # it "tokenizes a card" do
-  #   click_on('Card')
-  #
-  #   find('label[for="credit-card-number"]').click()
-  #   find('iframe[name="braintree-hosted-field-number"]').send_keys('4111111111111111')
-  #
-  #   find('label[for="expiration"]').click()
-  #   find('iframe[name="braintree-hosted-field-expirationDate"]').send_keys('12' + (Time.new.year + 2).to_s[-2..-1])
-  #
-  #   click_button('Pay')
-  #
-  #   # Drop-in Details
-  #   expect(page).to have_content('Ending in ••11')
-  #
-  #   # Nonce Details
-  #   expect(page).to have_content('CreditCard')
-  #   expect(page).to have_content('ending in 11')
-  #   expect(page).to have_content('Visa')
-  # end
+  describe "tokenizes" do
+    it "a card" do
+      click_option("Card")
+      hosted_field_send_input("number", "4111111111111111")
+      hosted_field_send_input("expirationDate", "1019")
+      submit_pay
 
-  it "tokenizes PayPal" do
-    find(".braintree-option__label", :text => "PayPal").click
+      expect(find(".braintree-heading")).to have_content("Paying with")
 
-    open_popup_and_complete_login
+      # Drop-in Details
+      expect(page).to have_content('Ending in ••11')
 
-    expect(page).to have_content('bt_buyer_us@paypal.com')
+      # Nonce Details
+      expect(page).to have_content('CreditCard')
+      expect(page).to have_content('ending in 11')
+      expect(page).to have_content('Visa')
+    end
+
+    it "PayPal" do
+      click_option("PayPal")
+
+      open_popup_and_complete_login
+
+      expect(find(".braintree-heading")).to have_content("Paying with")
+
+      expect(page).to have_content('bt_buyer_us@paypal.com')
+    end
   end
-
 end

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -1,12 +1,14 @@
 require_relative "helpers/paypal_helper"
 require_relative "helpers/drop_in_helper"
+require_relative "helpers/skip_browser_helper"
 
 HOSTNAME = `hostname`.chomp
 PORT = 4567
 
 describe "Drop-in" do
-  include PayPal
+  include SkipBrowser
   include DropIn
+  include PayPal
 
   before :each do
     visit "http://#{HOSTNAME}:#{PORT}"
@@ -14,6 +16,8 @@ describe "Drop-in" do
 
   describe "tokenizes" do
     it "a card" do
+      browser_skip("safari", "Testing iframes in WebKit does not work")
+
       click_option("Card")
       hosted_field_send_input("number", "4111111111111111")
       hosted_field_send_input("expirationDate", "1019")

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -10,6 +10,7 @@ describe "Drop-in" do
     visit "http://#{HOSTNAME}:#{PORT}"
   end
 
+  # TODO: Figure out how to focus to Hosted Fields in Drop-in.
   # it "tokenizes a card" do
   #   click_on('Card')
   #

--- a/spec/helpers/drop_in_helper.rb
+++ b/spec/helpers/drop_in_helper.rb
@@ -1,0 +1,14 @@
+module DropIn
+  def click_option(option_text)
+    find(".braintree-option__label", :text => option_text).click
+  end
+
+  def hosted_field_send_input(key, value)
+    find("iframe[id='braintree-hosted-field-#{key}']").click
+    find("iframe[id='braintree-hosted-field-#{key}']").send_keys(value)
+  end
+
+  def submit_pay
+    find("input[type='submit']").click
+  end
+end

--- a/spec/helpers/paypal_helper.rb
+++ b/spec/helpers/paypal_helper.rb
@@ -1,0 +1,20 @@
+module PayPal
+  def open_popup
+    return window_opened_by do
+      find('.paypal-button').click
+    end
+  end
+
+  def open_popup_and_complete_login
+    paypal_popup = open_popup
+
+    within_window paypal_popup do
+      wait_for_hermes_sandbox_to_load
+      click_link("return_url")
+    end
+  end
+
+  def wait_for_hermes_sandbox_to_load
+    expect(page).to have_text("Mock Sandbox Purchase Flow")
+  end
+end

--- a/spec/helpers/skip_browser_helper.rb
+++ b/spec/helpers/skip_browser_helper.rb
@@ -1,0 +1,10 @@
+module SkipBrowser
+  def browser_skip(browser_name, reason)
+    browser = page.driver.browser
+    detected_browser_name = browser.browser.to_s
+
+    if (detected_browser_name == browser_name)
+      skip(reason)
+    end
+  end
+end

--- a/spec/os.rb
+++ b/spec/os.rb
@@ -1,0 +1,30 @@
+# adapted from http://stackoverflow.com/a/171011/2601552
+module OS
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.mac?
+   (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.unix?
+    !OS.windows?
+  end
+
+  def OS.linux?
+    OS.unix? and not OS.mac?
+  end
+
+  def OS.get_sauce_bin
+    if OS.linux?
+      type = "linux"
+    elsif OS.mac?
+      type = "osx"
+    else
+      raise "Your OS is not supported for running these tests"
+    end
+
+    "./node_modules/sauce-connect-launcher/sc/sc-4.3.13-#{type}/bin/sc"
+  end
+end

--- a/spec/sauce_helper.rb
+++ b/spec/sauce_helper.rb
@@ -16,8 +16,7 @@ def select_browsers
   if !PLATFORM || PLATFORM == "desktop"
     browsers += [
       ["Windows 10", "chrome", nil],
-      # Firefox >= 48 on Sauce is failing all tests
-      ["Windows 10", "firefox", 47],
+      ["Windows 10", "firefox", nil],
       ["OS X 10.11", "safari", nil],
       ["Windows 7", "internet explorer", "9"],
       ["Windows 8", "internet explorer", "10"],

--- a/spec/sauce_helper.rb
+++ b/spec/sauce_helper.rb
@@ -1,0 +1,45 @@
+# File must reside at this location as the path is hardcoded in Sauce Parallel gem
+#
+# You should edit this file with the browsers you wish to use
+# For options, check out http://saucelabs.com/docs/platforms
+require "sauce"
+require "sauce/capybara"
+require_relative "./os"
+
+tunnel_id = "braintree-web-drop-in"
+
+PLATFORM = ENV["PLATFORM"]
+
+def select_browsers
+  browsers = []
+
+  if !PLATFORM || PLATFORM == "desktop"
+    browsers += [
+      ["Windows 10", "chrome", nil],
+      # Firefox >= 48 on Sauce is failing all tests
+      ["Windows 10", "firefox", 47],
+      ["OS X 10.11", "safari", nil],
+      ["Windows 7", "internet explorer", "9"],
+      ["Windows 8", "internet explorer", "10"],
+      ["Windows 10", "internet explorer", "11"],
+    ]
+  end
+
+  browsers
+end
+
+Capybara.default_driver = :sauce
+Sauce.config do |c|
+  c[:job_name] = tunnel_id
+  c[:application_host] = "https://#{`hostname`}"
+  c[:application_port] = 4443
+  c[:start_local_application] = false
+  c[:start_tunnel] = true
+  c[:connect_options] = {
+    :tunnel_identifier => tunnel_id,
+    :se_port => 4443
+  }
+  c["tunnel-identifier"] = tunnel_id
+  c[:sauce_connect_4_executable] = OS.get_sauce_bin
+  c[:browsers] = select_browsers
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,75 @@
+require "sauce"
+require "dotenv"
+require "capybara/rspec"
+require "parallel_tests"
+require "rspec/retry"
+
+Dotenv.load
+
+HOSTNAME = `hostname`.chomp
+PORT = 4567
+
+Capybara.default_driver = :selenium
+Capybara.app_host = "https://#{HOSTNAME}:#{PORT}"
+Capybara.default_max_wait_time = 20
+
+require_relative "sauce_helper"
+
+$pids = []
+
+def spawn_until_port(cmd, port)
+  `lsof -i :#{port}`
+  if $? != 0
+    puts "[STARTING] #{cmd} on #{port}"
+    $pids.push spawn(cmd, :out => "/dev/null")
+    wait_port(port)
+  end
+  puts "[RUNNING] #{cmd} on #{port}"
+end
+
+def download_sauce_connect
+  puts "[DOWNLOADING] Sauce connect"
+  `node -e "require('sauce-connect-launcher').download(function () {});"`
+  puts "[DOWNLOADED] Sauce connect"
+end
+
+def wait_port(port)
+  loop do
+    `lsof -i :#{port}`
+    sleep 2
+    break if $? == 0
+  end
+end
+
+RSpec.configure do |config|
+  config.include(Capybara::DSL)
+
+  config.verbose_retry = true
+  config.around(:each) do |c|
+    c.run_with_retry(retry: 2)
+  end
+
+  if ParallelTests.first_process?
+    config.before(:suite) do
+      download_sauce_connect
+      spawn_until_port("npm run development", PORT)
+      Sauce::Utilities::Connect.start
+    end
+
+    config.after(:suite) do
+      ParallelTests.wait_for_other_processes_to_finish
+      $pids.each do |pid|
+        Process.kill("INT", pid)
+      end
+      Sauce::Utilities::Connect.close
+    end
+  else
+    config.before(:suite) do
+      wait_port PORT
+    end
+  end
+
+  config.define_derived_metadata(:file_path => %r{/spec}) do |metadata|
+    metadata[:sauce] = true
+  end
+end


### PR DESCRIPTION
### Summary
Integration test setup for Drop-in web. Heavily references our [restricted-input](https://github.com/braintree/restricted-input) integration test setup.

There is one test that PayPal tokenizes so far. The goal of this PR was to get integration test setup, and we can add more integration tests afterwards.

### Checklist

- [X] Ran integration test
