### PR TITLE
Prepare package for publishing to npm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,3 +12,4 @@
 
   globals:
     __dirname: true
+    process: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,3 +9,6 @@
         requireReturn: true
         requireParamDescription: true
         requireReturnDescription: true
+
+  globals:
+    __dirname: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Use version 3.8.0 of braintree-web
 - Doesn't show Card payment option for merchants without cards enabled
+- Publish to npm
 
 1.0.0-beta.4
 ------------

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
 /* globals __dirname */
 
 var browserify = require('browserify');
+var envify = require('gulp-envify');
 var brfs = require('gulp-brfs');
 var cleanCSS = require('gulp-clean-css');
 var del = require('del');
@@ -114,6 +115,7 @@ gulp.task('build:npm:package.json', function (done) {
   var pkg = Object.assign({}, require('./package.json'));
 
   delete pkg.browserify;
+  pkg.main = 'index.js';
 
   mkdirp.sync(NPM_PATH);
 
@@ -124,6 +126,8 @@ gulp.task('build:npm:src', function () {
   return gulp.src([
     'src/**/*.js'
   ])
+  .pipe(replace('@DOT_MIN', ''))
+  .pipe(envify(process.env))
   .pipe(brfs())
   .pipe(gulp.dest(NPM_PATH));
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "brfs": "1.4.3",
     "browserify": "12.0.1",
     "chai": "3.4.1",
     "connect": "3.5.0",
@@ -23,6 +24,7 @@
     "eslint-config-braintree": "1.0.2",
     "finalhandler": "0.5.0",
     "gulp": "3.9.1",
+    "gulp-brfs": "0.1.0",
     "gulp-clean-css": "2.0.13",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
@@ -40,6 +42,7 @@
     "karma-mocha": "1.1.1",
     "karma-mocha-reporter": "2.0.3",
     "karma-phantomjs-launcher": "1.0.0",
+    "mkdirp": "0.5.1",
     "mocha": "3.0.0",
     "packageify": "0.2.3",
     "phantomjs-prebuilt": "2.1.13",
@@ -47,7 +50,6 @@
     "serve-static": "1.11.1",
     "sinon": "1.17.4",
     "sinon-chai": "2.8.0",
-    "stringify": "5.1.0",
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
@@ -55,7 +57,7 @@
   },
   "browserify": {
     "transform": [
-      "packageify"
+      "brfs"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "chai": "3.4.1",
     "connect": "3.5.0",
     "del": "2.2.2",
+    "envify": "4.0.0",
     "eslint": "2.7.0",
     "eslint-config-braintree": "1.0.2",
     "finalhandler": "0.5.0",
     "gulp": "3.9.1",
     "gulp-brfs": "0.1.0",
     "gulp-clean-css": "2.0.13",
+    "gulp-envify": "1.0.0",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
     "gulp-sass": "2.3.2",
@@ -44,7 +46,6 @@
     "karma-phantomjs-launcher": "1.0.0",
     "mkdirp": "0.5.1",
     "mocha": "3.0.0",
-    "packageify": "0.2.3",
     "phantomjs-prebuilt": "2.1.13",
     "run-sequence": "1.2.2",
     "serve-static": "1.11.1",
@@ -57,7 +58,13 @@
   },
   "browserify": {
     "transform": [
-      "brfs"
+      "brfs",
+      [
+        "envify",
+        {
+          "_": "purge"
+        }
+      ]
     ]
   }
 }

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -10,10 +10,11 @@ var isGuestCheckout = require('./lib/is-guest-checkout');
 var fs = require('fs');
 var translations = require('./translations');
 var uuid = require('./lib/uuid');
-var VERSION = require('package.version');
 
 var mainHTML = fs.readFileSync(__dirname + '/html/main.html', 'utf8');
 var svgHTML = fs.readFileSync(__dirname + '/html/svgs.html', 'utf8');
+
+var VERSION = process.env.npm_package_version;
 
 function Dropin(options) {
   this._client = options.client;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -7,11 +7,13 @@ var constants = require('./constants');
 var DropinModel = require('./dropin-model');
 var EventEmitter = require('./lib/event-emitter');
 var isGuestCheckout = require('./lib/is-guest-checkout');
-var mainHTML = require('./html/main.html');
+var fs = require('fs');
 var translations = require('./translations');
-var svgHTML = require('./html/svgs.html');
 var uuid = require('./lib/uuid');
 var VERSION = require('package.version');
+
+var mainHTML = fs.readFileSync(__dirname + '/html/main.html', 'utf8');
+var svgHTML = fs.readFileSync(__dirname + '/html/svgs.html', 'utf8');
 
 function Dropin(options) {
   this._client = options.client;

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,13 @@
  * @description This is the Drop-in module.
  */
 
-var packageVersion = require('package.version');
 var Dropin = require('./dropin');
 var client = require('braintree-web/client');
 var deferred = require('./lib/deferred');
 var constants = require('./constants');
 var analytics = require('./lib/analytics');
+
+var VERSION = process.env.npm_package_version;
 
 /**
  * @static
@@ -73,5 +74,5 @@ module.exports = {
    * @description The current version of Drop-in, i.e. `{@pkg version}`.
    * @type {string}
    */
-  VERSION: packageVersion
+  VERSION: VERSION
 };

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -3,7 +3,9 @@
 var BaseView = require('./base-view');
 var classlist = require('../lib/classlist');
 var constants = require('../constants');
-var paymentMethodHTML = require('../html/payment-method.html');
+var fs = require('fs');
+
+var paymentMethodHTML = fs.readFileSync(__dirname + '/../html/payment-method.html', 'utf8');
 
 function PaymentMethodView() {
   BaseView.apply(this, arguments);

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -2,8 +2,10 @@
 
 var analytics = require('../lib/analytics');
 var BaseView = require('./base-view');
-var paymentMethodOptionHTML = require('../html/payment-option.html');
+var fs = require('fs');
 var paymentOptionIDs = require('../constants').paymentOptionIDs;
+
+var paymentMethodOptionHTML = fs.readFileSync(__dirname + '/../html/payment-option.html', 'utf8');
 
 function PaymentOptionsView() {
   BaseView.apply(this, arguments);

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -1,10 +1,12 @@
 'use strict';
 
+var fs = require('fs');
 var BaseView = require('../base-view');
-var cardIconHTML = require('../../html/card-icons.html');
 var classlist = require('../../lib/classlist');
 var constants = require('../../constants');
 var hostedFields = require('braintree-web/hosted-fields');
+
+var cardIconHTML = fs.readFileSync(__dirname + '/../../html/card-icons.html', 'utf8');
 
 function CardView() {
   BaseView.apply(this, arguments);

--- a/test/config/karma.js
+++ b/test/config/karma.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
     },
     browserify: {
       extensions: ['.js', '.json'],
-      transform: ['stringify'],
+      transform: require('../../package.json').browserify.transform,
       ignore: [],
       watch: true,
       debug: true,

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -8,13 +8,15 @@ var analytics = require('../../../src/lib/analytics');
 var classlist = require('../../../src/lib/classlist');
 var DropinModel = require('../../../src/dropin-model');
 var fake = require('../../helpers/fake');
+var fs = require('fs');
 var HostedFields = require('braintree-web/hosted-fields');
 var PaymentOptionsView = require('../../../src/views/payment-options-view');
 var PayPalView = require('../../../src/views/payment-sheet-views/paypal-view');
 var PayPal = require('braintree-web/paypal');
 var sheetViews = require('../../../src/views/payment-sheet-views');
 var strings = require('../../../src/translations/en');
-var templateHTML = require('../../../src/html/main.html');
+
+var templateHTML = fs.readFileSync(__dirname + '/../../../src/html/main.html', 'utf8');
 
 describe('MainView', function () {
   beforeEach(function () {

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -1,9 +1,11 @@
 'use strict';
 
 var BaseView = require('../../../src/views/base-view');
+var fs = require('fs');
 var PaymentMethodView = require('../../../src/views/payment-method-view');
-var paymentMethodHTML = require('../../../src/html/payment-method.html');
 var strings = require('../../../src/translations/en');
+
+var paymentMethodHTML = fs.readFileSync(__dirname + '/../../../src/html/payment-method.html', 'utf8');
 
 describe('PaymentMethodView', function () {
   beforeEach(function () {

--- a/test/unit/views/payment-methods-view.js
+++ b/test/unit/views/payment-methods-view.js
@@ -4,8 +4,10 @@ var BaseView = require('../../../src/views/base-view');
 var PaymentMethodsView = require('../../../src/views/payment-methods-view');
 var DropinModel = require('../../../src/dropin-model');
 var fake = require('../../helpers/fake');
-var mainHTML = require('../../../src/html/main.html');
+var fs = require('fs');
 var strings = require('../../../src/translations/en');
+
+var mainHTML = fs.readFileSync(__dirname + '/../../../src/html/main.html', 'utf8');
 
 describe('PaymentMethodsView', function () {
   describe('Constructor', function () {

--- a/test/unit/views/payment-options-view.js
+++ b/test/unit/views/payment-options-view.js
@@ -2,12 +2,14 @@
 
 var BaseView = require('../../../src/views/base-view');
 var CardView = require('../../../src/views/payment-sheet-views/card-view');
-var mainHTML = require('../../../src/html/main.html');
 var PaymentOptionsView = require('../../../src/views/payment-options-view');
 var DropinModel = require('../../../src/dropin-model');
 var strings = require('../../../src/translations/en');
 var fake = require('../../helpers/fake');
+var fs = require('fs');
 var analytics = require('../../../src/lib/analytics');
+
+var mainHTML = fs.readFileSync(__dirname + '/../../../src/html/main.html', 'utf8');
 
 describe('PaymentOptionsView', function () {
   describe('Constructor', function () {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -5,9 +5,11 @@ var CardView = require('../../../../src/views/payment-sheet-views/card-view');
 var classlist = require('../../../../src/lib/classlist');
 var DropinModel = require('../../../../src/dropin-model');
 var fake = require('../../../helpers/fake');
+var fs = require('fs');
 var hostedFields = require('braintree-web/hosted-fields');
-var mainHTML = require('../../../../src/html/main.html');
 var strings = require('../../../../src/translations/en');
+
+var mainHTML = fs.readFileSync(__dirname + '/../../../../src/html/main.html', 'utf8');
 
 describe('CardView', function () {
   beforeEach(function () {

--- a/test/unit/views/payment-sheet-views/paypal-view.js
+++ b/test/unit/views/payment-sheet-views/paypal-view.js
@@ -3,9 +3,11 @@
 var BaseView = require('../../../../src/views/base-view');
 var DropinModel = require('../../../../src/dropin-model');
 var fake = require('../../../helpers/fake');
-var mainHTML = require('../../../../src/html/main.html');
+var fs = require('fs');
 var PayPal = require('braintree-web/paypal');
 var PayPalView = require('../../../../src/views/payment-sheet-views/paypal-view');
+
+var mainHTML = fs.readFileSync(__dirname + '/../../../../src/html/main.html', 'utf8');
 
 describe('PayPalView', function () {
   beforeEach(function () {


### PR DESCRIPTION
### Summary

This prepares Drop-in for a publish to `npm`. It fills `dist/npm` with files ready to be `npm publish`ed.

We tested this by doing something like this in another project (and getting all the way to tokenization):

```js
// ...
"dependencies": {
  "braintree-web-drop-in": "/path/to/braintree-web-drop-in/dist/npm"
},
// ...
```

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests