### PR TITLE
Add instructions for getting hosted Drop-in files to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Because we're still in beta, the API and designs are subject to change. If you h
 - Not in an iframe; feel free to style Drop-in to blend in with your website
 - Open source and open development
 
+## Setup
+
+Drop-in is currently available directly from our servers, which you can save locally or include in your project through a script tag:
+
+```
+<script src="https://js.braintreegateway.com/web/dropin/1.0.0-beta.4/js/dropin.min.js"></script>
+```
+
 ## Basic usage
 
 Drop-in provides a payment method object containing the [payment method nonce](https://developers.braintreepayments.com/start/overview#payment-method-nonce) to send to your server. To get this object, use the `requestPaymentMethod` function as shown below.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because we're still in beta, the API and designs are subject to change. If you h
 
 Drop-in is currently available directly from our servers, which you can save locally or include in your project through a script tag:
 
-```
+```html
 <script src="https://js.braintreegateway.com/web/dropin/1.0.0-beta.4/js/dropin.min.js"></script>
 ```
 


### PR DESCRIPTION
### Summary

Adds some clarification on how to get Drop-in. We'll add npm installation instructions here once it's available. We could also add a bit about how we support browserify/webpack but that might be better suited for the someday dev docs. 

### Checklist

~Added a changelog entry~
~Ran unit tests~
