### PR TITLE
Remove min-width rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ unreleased
 - Animate choosing a different way to pay
 - Switch PayPal component for PayPal Checkout component
 - Publish to npm
+- Fix #85 where the Drop-in would overflow in a small container
 
 1.0.0-beta.4
 ------------

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,7 +20,6 @@ $curve-easeOutBack: cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
 .braintree-dropin {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  min-width: 290px;
   margin: 0;
   padding: 0;
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,6 +20,7 @@ $curve-easeOutBack: cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
 .braintree-dropin {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  min-width: 200px;
   margin: 0;
   padding: 0;
 


### PR DESCRIPTION
Closes #85

### Summary

The min-width property was causing the drop-in to overflow on smaller containers.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
