### PR TITLE
Add method to update PayPal config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ unreleased
 - Animate choosing a different way to pay
 - Switch PayPal component for PayPal Checkout component
 - Publish to npm
+- Add `setPayPalOption` method to dynamically change PayPal config options. Closes #87
 
 1.0.0-beta.4
 ------------

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ dropinInstance.setPayPalOption('amount', '20.00');
 dropinInstance.setPayPalOption('intent', null);
 ```
 
+Note: if your customer has already authenticated their PayPal account, using `setPayPalOption` will not make any changes for this session. If the customer chooses to pick another way to pay and authenticates with PayPal again, the changes you make to the PayPal options will be used.
+
 ## Full example
 
 This is a full example of a Drop-in integration that only accepts credit cards.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ The structure of the PayPal payment method object returned in the callback of `r
 If you need to update a field (such as the amount) after creation, you can do so with the `setPayPalOption` method.
 
 ```js
+// set amount to 20.00
 dropinInstance.setPayPalOption('amount', '20.00');
+
+// remove intent from options
+dropinInstance.setPayPalOption('intent', null);
 ```
 
 ## Full example

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ You can find more PayPal configuration options in the [Braintree JS client SDK v
 
 The structure of the PayPal payment method object returned in the callback of `requestPaymentMethod` can be found [here](http://braintree.github.io/braintree-web/current/PayPal.html#~tokenizePayload).
 
+If you need to update a field (such as the amount) after creation, you can do so with the `setPayPalOption` method.
+
+```js
+dropinInstance.setPayPalOption('amount', '20.00');
+```
+
 ## Full example
 
 This is a full example of a Drop-in integration that only accepts credit cards.

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -3,6 +3,7 @@
 var assign = require('./lib/assign').assign;
 var analytics = require('./lib/analytics');
 var MainView = require('./views/main-view');
+var PayPalView = require('./views/payment-sheet-views/paypal-view');
 var constants = require('./constants');
 var DropinModel = require('./dropin-model');
 var EventEmitter = require('./lib/event-emitter');
@@ -153,12 +154,22 @@ Dropin.prototype._getVaultedPaymentMethods = function (callback) {
 Dropin.prototype.setPayPalOption = function (option, value) {
   if (!this._merchantConfiguration.paypal) {
     throw new Error('PayPal not enabled.');
+  } else if (this._paypalAuthInProgress()) {
+    throw new Error('PayPal auth in progress.');
   }
+
   if (value == null) {
     delete this._merchantConfiguration.paypal[option];
   } else {
     this._merchantConfiguration.paypal[option] = value;
   }
+};
+
+Dropin.prototype._paypalAuthInProgress = function () {
+  var activeView = this._mainView.primaryView;
+  var paypalIsActiveView = activeView instanceof PayPalView;
+
+  return Boolean(paypalIsActiveView && activeView.authInProgress);
 };
 
 Dropin.prototype.teardown = function (callback) {

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -23,7 +23,7 @@ function Dropin(options) {
   this._dropinWrapper.id = 'braintree--dropin__' + this._componentID;
   this._dropinWrapper.setAttribute('data-braintree-id', 'wrapper');
   this._dropinWrapper.style.display = 'none';
-  this._merchantConfiguration = options.merchantConfiguration;
+  this._merchantConfiguration = assign({}, options.merchantConfiguration);
 
   EventEmitter.call(this);
 }

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -150,6 +150,17 @@ Dropin.prototype._getVaultedPaymentMethods = function (callback) {
   }
 };
 
+Dropin.prototype.setPayPalOption = function (option, value) {
+  if (!this._merchantConfiguration.paypal) {
+    throw new Error('PayPal not enabled.');
+  }
+  if (value == null) {
+    delete this._merchantConfiguration.paypal[option];
+  } else {
+    this._merchantConfiguration.paypal[option] = value;
+  }
+};
+
 Dropin.prototype.teardown = function (callback) {
   this._removeStylesheet();
 

--- a/src/views/payment-sheet-views/paypal-view.js
+++ b/src/views/payment-sheet-views/paypal-view.js
@@ -48,11 +48,13 @@ PayPalView.prototype._initialize = function () {
       env: environment,
       locale: merchantConfig.locale,
       payment: function () {
+        self.authInProgress = true;
         return paypalInstance.createPayment(merchantConfig).catch(reportError);
       },
       onAuthorize: function (data) {
         return paypalInstance.tokenizePayment(data).then(function (tokenizePayload) {
           self.model.addPaymentMethod(tokenizePayload);
+          self.authInProgress = false;
         }).catch(reportError);
       },
       onError: reportError
@@ -64,6 +66,7 @@ PayPalView.prototype._initialize = function () {
   });
 
   function reportError(err) {
+    self.authInProgress = false;
     self.model.reportError(err);
   }
 };

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -3,6 +3,7 @@
 var Dropin = require('../../src/dropin/');
 var deferred = require('../../src/lib/deferred');
 var DropinModel = require('../../src/dropin-model');
+var PayPalView = require('../../src/views/payment-sheet-views/paypal-view');
 var EventEmitter = require('../../src/lib/event-emitter');
 var analytics = require('../../src/lib/analytics');
 var fake = require('../helpers/fake');
@@ -401,6 +402,8 @@ describe('Dropin', function () {
         amount: '28.00',
         currency: 'USD'
       };
+      this.instance = new Dropin(this.dropinOptions);
+      this.instance._mainView = {};
     });
 
     it('throws an error if PayPal is not enabled', function () {
@@ -414,28 +417,32 @@ describe('Dropin', function () {
       }).to.throw('PayPal not enabled.');
     });
 
+    it('throws an error if PayPal auth is in progress', function () {
+      this.sandbox.stub(PayPalView.prototype, '_initialize');
+      this.instance._mainView.primaryView = new PayPalView();
+      this.instance._mainView.primaryView.authInProgress = true;
+
+      expect(function () {
+        this.instance.setPayPalOption('amount', '10.00');
+      }.bind(this)).to.throw('PayPal auth in progress.');
+    });
+
     it('sets PayPal option to provided value', function () {
-      var instance = new Dropin(this.dropinOptions);
+      this.instance.setPayPalOption('amount', '10.00');
 
-      instance.setPayPalOption('amount', '10.00');
-
-      expect(instance._merchantConfiguration.paypal.amount).to.equal('10.00');
+      expect(this.instance._merchantConfiguration.paypal.amount).to.equal('10.00');
     });
 
     it('removes PayPal option when value provided is null', function () {
-      var instance = new Dropin(this.dropinOptions);
+      this.instance.setPayPalOption('amount', null);
 
-      instance.setPayPalOption('amount', null);
-
-      expect(instance._merchantConfiguration.paypal.amount).to.be.undefined;
+      expect(this.instance._merchantConfiguration.paypal.amount).to.be.undefined;
     });
 
     it('removes PayPal option when value provided is undefined', function () {
-      var instance = new Dropin(this.dropinOptions);
+      this.instance.setPayPalOption('amount');
 
-      instance.setPayPalOption('amount');
-
-      expect(instance._merchantConfiguration.paypal.amount).to.be.undefined;
+      expect(this.instance._merchantConfiguration.paypal.amount).to.be.undefined;
     });
   });
 

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -386,6 +386,51 @@ describe('Dropin', function () {
     });
   });
 
+  describe('setPayPalOption', function () {
+    beforeEach(function () {
+      this.dropinOptions.merchantConfiguration.paypal = {
+        flow: 'checkout',
+        amount: '28.00',
+        currency: 'USD'
+      };
+    });
+
+    it('throws an error if PayPal is not enabled', function () {
+      var instance;
+
+      delete this.dropinOptions.merchantConfiguration.paypal;
+      instance = new Dropin(this.dropinOptions);
+
+      expect(function () {
+        instance.setPayPalOption('amount', '10.00');
+      }).to.throw('PayPal not enabled.');
+    });
+
+    it('sets PayPal option to provided value', function () {
+      var instance = new Dropin(this.dropinOptions);
+
+      instance.setPayPalOption('amount', '10.00');
+
+      expect(instance._merchantConfiguration.paypal.amount).to.equal('10.00');
+    });
+
+    it('removes PayPal option when value provided is null', function () {
+      var instance = new Dropin(this.dropinOptions);
+
+      instance.setPayPalOption('amount', null);
+
+      expect(instance._merchantConfiguration.paypal.amount).to.be.undefined;
+    });
+
+    it('removes PayPal option when value provided is undefined', function () {
+      var instance = new Dropin(this.dropinOptions);
+
+      instance.setPayPalOption('amount');
+
+      expect(instance._merchantConfiguration.paypal.amount).to.be.undefined;
+    });
+  });
+
   describe('requestPaymentMethod', function () {
     it('calls the requestPaymentMethod function of the MainView', function (done) {
       var instance = new Dropin(this.dropinOptions);

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -43,6 +43,14 @@ describe('Dropin', function () {
     it('inherits from EventEmitter', function () {
       expect(new Dropin(this.dropinOptions)).to.be.an.instanceOf(EventEmitter);
     });
+
+    it('clones merchant configuration', function () {
+      var instance = new Dropin(this.dropinOptions);
+
+      this.dropinOptions.merchantConfiguration.selector = '#bar';
+
+      expect(instance._merchantConfiguration.selector).to.equal('#foo');
+    });
   });
 
   describe('_initialize', function () {


### PR DESCRIPTION
Closes #87

### Summary

Adds a method to dynamically update the PayPal config.

Also clones the merchant config, to prevent tampering with the object after creation.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
