### PR TITLE
Show loading indicator until all async dependencies are done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ unreleased
 - Animate choosing a different way to pay
 - Publish to npm
 - Fix #85 where the Drop-in would overflow in a small container
+- Show loading indicator until all components have finished loading
 
 1.0.0-beta.4
 ------------

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -62,14 +62,6 @@ DropinModel.prototype.asyncDependencyReady = function () {
   }
 };
 
-DropinModel.prototype.beginLoading = function () {
-  this._emit('loadBegin');
-};
-
-DropinModel.prototype.endLoading = function () {
-  this._emit('loadEnd');
-};
-
 DropinModel.prototype.reportError = function (error) {
   this._emit('errorOccurred', error);
 };

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -38,7 +38,6 @@ MainView.prototype._initialize = function () {
 
   this.supportsFlexbox = supportsFlexbox();
 
-  this.model.on('loadBegin', this.showLoadingIndicator.bind(this));
   this.model.on('loadEnd', this.hideLoadingIndicator.bind(this));
 
   this.model.on('errorOccurred', this.showSheetError.bind(this));
@@ -146,7 +145,6 @@ MainView.prototype.setPrimaryView = function (id) {
   }
 
   this.model.clearError();
-  this.model.endLoading();
 };
 
 MainView.prototype.requestPaymentMethod = function (callback) {
@@ -164,12 +162,6 @@ MainView.prototype.requestPaymentMethod = function (callback) {
     analytics.sendEvent(this.client, 'request-payment-method.' + analyticsKinds[payload.type]);
     callback(null, payload);
   }.bind(this));
-};
-
-MainView.prototype.showLoadingIndicator = function () {
-  classlist.remove(this.loadingIndicator, 'braintree-loader__indicator--inactive');
-  classlist.remove(this.loadingContainer, 'braintree-loader__container--inactive');
-  classlist.add(this.dropinContainer, 'braintree-hidden');
 };
 
 MainView.prototype.hideLoadingIndicator = function () {

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -95,13 +95,12 @@ CardView.prototype._initialize = function () {
     delete hfOptions.fields.postalCode;
   }
 
-  this.model.beginLoading();
   this.model.asyncDependencyStarting();
 
   hostedFields.create(hfOptions, function (err, hostedFieldsInstance) {
     if (err) {
       this.model.reportError(err);
-      this.model.endLoading();
+      this.model.asyncDependencyReady(); // TODO: replace with asyncDependencyFailed
       return;
     }
 
@@ -113,7 +112,6 @@ CardView.prototype._initialize = function () {
     this.hostedFieldsInstance.on('validityChange', this._onValidityChangeEvent.bind(this));
 
     this.model.asyncDependencyReady();
-    this.model.endLoading();
   }.bind(this));
 };
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -251,30 +251,6 @@ describe('DropinModel', function () {
     });
   });
 
-  describe('beginLoading', function () {
-    it('emits a loadBegin event', function (done) {
-      var model = new DropinModel(this.modelOptions);
-
-      model.on('loadBegin', function () {
-        done();
-      });
-
-      model.beginLoading();
-    });
-  });
-
-  describe('endLoading', function () {
-    it('emits a loadEnd event', function (done) {
-      var model = new DropinModel(this.modelOptions);
-
-      model.on('loadEnd', function () {
-        done();
-      });
-
-      model.endLoading();
-    });
-  });
-
   describe('reportError', function () {
     it('emits an errorOccurred event with the error', function (done) {
       var dropinModel = new DropinModel(this.modelOptions);

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -493,28 +493,6 @@ describe('MainView', function () {
     });
   });
 
-  describe('showLoadingIndicator', function () {
-    it('shows the loading indicator', function () {
-      var dropinContainer = document.createElement('div');
-      var loadingContainer = document.createElement('div');
-      var loadingIndicator = document.createElement('div');
-      var context = {
-        dropinContainer: dropinContainer,
-        loadingContainer: loadingContainer,
-        loadingIndicator: loadingIndicator
-      };
-
-      loadingContainer.className = 'braintree-loader__container--inactive';
-      loadingIndicator.className = 'braintree-loader__indicator--inactive';
-
-      MainView.prototype.showLoadingIndicator.call(context);
-
-      expect(context.dropinContainer.classList.contains('braintree-hidden')).to.be.true;
-      expect(context.loadingContainer.classList.contains('braintree-loader__container--inactive')).to.be.false;
-      expect(context.loadingIndicator.classList.contains('braintree-loader__indicator--inactive')).to.be.false;
-    });
-  });
-
   describe('hideLoadingIndicator', function () {
     beforeEach(function () {
       this.clock = sinon.useFakeTimers();
@@ -562,24 +540,9 @@ describe('MainView', function () {
       };
 
       this.sandbox.stub(CardView.prototype, '_initialize');
-      this.sandbox.stub(this.model, 'beginLoading');
-      this.sandbox.stub(this.model, 'endLoading');
-      this.sandbox.spy(MainView.prototype, 'showLoadingIndicator');
       this.sandbox.spy(MainView.prototype, 'hideLoadingIndicator');
 
       this.mainView = new MainView(this.mainViewOptions);
-    });
-
-    it('calls showLoadingIndicator on loadBegin', function () {
-      this.model._emit('loadBegin');
-
-      expect(MainView.prototype.showLoadingIndicator).to.be.calledOnce;
-    });
-
-    it('calls hideLoadingIndicator on loadEnd', function () {
-      this.model._emit('loadEnd');
-
-      expect(MainView.prototype.hideLoadingIndicator).to.be.calledOnce;
     });
 
     describe('for changeActivePaymentView', function () {


### PR DESCRIPTION
### Summary
Currently, the loading indicator disappears before the PayPal component has finished loading.

The card view calls `this.model.endLoading()`, which hides the loading indicator and shows the payment options. At this point, the PayPal component may not be finished loading yet. [The model already emits `loadEnd`](https://github.com/braintree/braintree-web-drop-in/blob/4660e73/src/dropin-model.js#L60) when the async dependencies are ready.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests