### PR TITLE
Test app - Clear error when requestPaymentMethod succeeds

### DIFF
--- a/test/app/index.html
+++ b/test/app/index.html
@@ -88,8 +88,10 @@
       dropinInstance.requestPaymentMethod(function (err, payload) {
         if (err) {
           error.textContent = err.message;
+          results.textContent = '';
         } else {
           results.textContent = JSON.stringify(payload, null, 2);
+          error.textContent = '';
         }
       });
     }, false);


### PR DESCRIPTION
### Summary
When `requestPaymentMethod` returns an error, the test app displays it on the page. It remains there even when a subsequent request succeeds. This removes it.