### PR TITLE
Add `paymentOptionPriority` option for specifying payment option ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## UNRELEASED
 -------------
 - Disable payment methods if they error when creating
+- Add `order` option for specifying the ordering of payment options such as `card` and `paypal`
 
 1.0.0-beta.5
 ------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 ## UNRELEASED
 -------------
 - Disable payment methods if they error when creating
-- Add `order` option for specifying the ordering of payment options such as `card` and `paypal`
+- Add `paymentOptionPriority` option for specifying the ordering of payment options such as `card` and `paypal`
 
 1.0.0-beta.5
 ------------

--- a/README.md
+++ b/README.md
@@ -121,13 +121,14 @@ This is a full example of a Drop-in integration that only accepts credit cards.
 </html>
 ```
 
-## Payment option ordering
+## Payment option priority
 
-By default, Drop-in displays the credit/debit card form first, followed by PayPal (if enabled). You can customize this ordering with `order` as shown in this example:
+By default, Drop-in displays the credit/debit card form first, followed by PayPal (if enabled). You can customize this ordering with `paymentOptionPriority` as shown in this example:
+
 ```js
 braintree.dropin.create({
   // ...
-  order: ['paypal', 'card'] // Display PayPal first
+  paymentOptionPriority: ['paypal', 'card'] // Display PayPal first
 }, /* ... */);
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ This is a full example of a Drop-in integration that only accepts credit cards.
 </html>
 ```
 
+## Payment option ordering
+
+By default, Drop-in displays the credit/debit card form first, followed by PayPal (if enabled). You can customize this ordering with `order` as shown in this example:
+```js
+braintree.dropin.create({
+  // ...
+  order: ['paypal', 'card'] // Display PayPal first
+}, /* ... */);
+```
+
+Payment options omitted from this array will not be offered to the customer.
+
 ## Teardown
 
 When you want to cleanly tear down anything set up by `dropin.create`, use `teardown()`. This may be useful in a single-page app.

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -32,6 +32,36 @@ describe "Drop-in" do
     end
   end
 
+  describe "payment option priority" do
+    it "uses default priority of card, paypal" do
+      visit "http://#{HOSTNAME}:#{PORT}"
+
+      find(".braintree-heading")
+      payment_options = all(:css, ".braintree-option__label")
+
+      expect(payment_options[0]).to have_content("Card")
+      expect(payment_options[1]).to have_content("PayPal")
+    end
+
+    it "uses custom priority of paypal, card" do
+      options = '["paypal","card"]'
+      visit "http://#{HOSTNAME}:#{PORT}?paymentOptionPriority=#{options}"
+
+      find(".braintree-heading")
+      payment_options = all(:css, ".braintree-option__label")
+
+      expect(payment_options[0]).to have_content("PayPal")
+      expect(payment_options[1]).to have_content("Card")
+    end
+
+    it "shows an error when an unrecognized payment option is specified" do
+      options = '["dummy","card"]'
+      visit "http://#{HOSTNAME}:#{PORT}?paymentOptionPriority=#{options}"
+
+      expect(find("#error")).to have_content("paymentOptionPriority: Invalid payment option specified.")
+    end
+  end
+
   describe "tokenizes" do
     it "a card" do
       browser_skip("safari", "Testing iframes in WebKit does not work")

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -85,16 +85,16 @@ DropinModel.prototype.clearError = function () {
 
 function getSupportedPaymentOptions(options) {
   var result = [];
-  var order = options.merchantConfiguration.order || ['card', 'paypal'];
+  var paymentOptionPriority = options.merchantConfiguration.paymentOptionPriority || ['card', 'paypal'];
 
-  if (!(order instanceof Array)) {
-    throw new Error('order must be an array.');
+  if (!(paymentOptionPriority instanceof Array)) {
+    throw new Error('paymentOptionPriority must be an array.');
   }
 
   // Remove duplicates
-  order = order.filter(function (item, pos) { return order.indexOf(item) === pos; });
+  paymentOptionPriority = paymentOptionPriority.filter(function (item, pos) { return paymentOptionPriority.indexOf(item) === pos; });
 
-  order.forEach(function (paymentOption) {
+  paymentOptionPriority.forEach(function (paymentOption) {
     if (isPaymentOptionEnabled(paymentOption, options)) {
       result.push(paymentOptionIDs[paymentOption]);
     }
@@ -115,7 +115,7 @@ function isPaymentOptionEnabled(paymentOption, options) {
   } else if (paymentOption === 'paypal') {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypal);
   }
-  throw new Error('order: Invalid payment option specified.');
+  throw new Error('paymentOptionPriority: Invalid payment option specified.');
 }
 
 module.exports = DropinModel;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -79,9 +79,9 @@ Dropin.prototype._initialize = function (callback) {
         merchantConfiguration: this._merchantConfiguration,
         paymentMethods: paymentMethods
       });
-    } catch (err) {
-      dropinInstance.teardown(function (teardownErr) {
-        callback(teardownErr || err);
+    } catch (modelError) {
+      dropinInstance.teardown(function () {
+        callback(modelError);
       });
       return;
     }

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -57,6 +57,9 @@
   <input type="submit" value="Pay">
 </form>
 
+<button id="create-button">Create</button>
+<button id="teardown-button">Teardown</button>
+
 <pre id="results"></pre>
 
 <script src="/web/dropin/dev/js/dropin.js"></script>
@@ -64,37 +67,51 @@
 <script>
 
   var authorization = 'sandbox_g42y39zw_348pk9cgf3bgyw2b';
+  var dropinInstance;
+  var createButton = document.querySelector('#create-button');
+  var teardownButton = document.querySelector('#teardown-button');
 
-  braintree.dropin.create({
-    authorization: authorization,
-    selector: '#dropin-container',
-    paypal: {
-      flow: 'vault'
-    }
-  }, function (err, dropinInstance) {
-    var form = document.querySelector('#checkout-form');
-    var results = document.querySelector('#results');
-    var error = document.querySelector('#error');
+  createButton.addEventListener('click', function () {
+    braintree.dropin.create({
+      authorization: authorization,
+      selector: '#dropin-container',
+      paypal: {
+        flow: 'vault'
+      }
+      }, function (err, instance) {
+      var form = document.querySelector('#checkout-form');
+      var results = document.querySelector('#results');
+      var error = document.querySelector('#error');
 
-    if (err) {
-      console.error('There was an error creating Drop-in.');
-      error.textContent = err.message;
-      throw err;
-    }
+      if (err) {
+        console.error('There was an error creating Drop-in.');
+        error.textContent = err.message;
+        throw err;
+      }
 
-    form.addEventListener('submit', function (event) {
-      event.preventDefault();
+      dropinInstance = instance;
 
-      dropinInstance.requestPaymentMethod(function (err, payload) {
-        if (err) {
-          error.textContent = err.message;
-          results.textContent = '';
-        } else {
-          results.textContent = JSON.stringify(payload, null, 2);
-          error.textContent = '';
-        }
-      });
-    }, false);
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+
+        dropinInstance.requestPaymentMethod(function (err, payload) {
+          if (err) {
+            error.textContent = err.message;
+            results.textContent = '';
+          } else {
+            results.textContent = JSON.stringify(payload, null, 2);
+            error.textContent = '';
+          }
+        });
+      }, false);
+    });
+  });
+
+  teardownButton.addEventListener('click', function () {
+    dropinInstance.teardown(function (err) {
+      if (err) { console.error('Failed to tear down:', err); }
+      else { console.log('Teardown successful'); }
+    });
   });
 
 </script>

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -61,7 +61,9 @@ describe('DropinModel', function () {
       it('supports nothing', function () {
         this.configuration.gatewayConfiguration.creditCards.supportedCardTypes = [];
 
-        expect(new DropinModel(this.modelOptions).supportedPaymentOptions).to.deep.equal([]);
+        expect(function () {
+          new DropinModel(this.modelOptions); // eslint-disable-line no-new
+        }.bind(this)).to.throw('No valid payment options available.');
       });
 
       it('supports cards', function () {
@@ -78,6 +80,18 @@ describe('DropinModel', function () {
           'card',
           'paypal'
         ]);
+      });
+
+      it('uses custom order of payment options', function () {
+        var model;
+
+        this.configuration.gatewayConfiguration.paypalEnabled = true;
+        this.modelOptions.merchantConfiguration.paypal = true;
+        this.modelOptions.merchantConfiguration.order = ['paypal', 'card'];
+
+        model = new DropinModel(this.modelOptions);
+
+        expect(model.supportedPaymentOptions).to.deep.equal(['paypal', 'card']);
       });
     });
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -58,8 +58,18 @@ describe('DropinModel', function () {
     });
 
     describe('supported payment options', function () {
-      it('supports nothing', function () {
+      it('throws an error when there are no payment options', function () {
         this.configuration.gatewayConfiguration.creditCards.supportedCardTypes = [];
+
+        expect(function () {
+          new DropinModel(this.modelOptions); // eslint-disable-line no-new
+        }.bind(this)).to.throw('No valid payment options available.');
+      });
+
+      it('throws an error when order is an empty array', function () {
+        this.configuration.gatewayConfiguration.paypalEnabled = true;
+        this.modelOptions.merchantConfiguration.paypal = true;
+        this.modelOptions.merchantConfiguration.order = [];
 
         expect(function () {
           new DropinModel(this.modelOptions); // eslint-disable-line no-new
@@ -72,14 +82,15 @@ describe('DropinModel', function () {
         ]);
       });
 
-      it('supports credit cards and PayPal if PayPal is enabled by merchant and gateway', function () {
+      it('supports cards and paypal and defaults to showing them in correct order', function () {
+        var model;
+
         this.configuration.gatewayConfiguration.paypalEnabled = true;
         this.modelOptions.merchantConfiguration.paypal = true;
 
-        expect(new DropinModel(this.modelOptions).supportedPaymentOptions).to.have.members([
-          'card',
-          'paypal'
-        ]);
+        model = new DropinModel(this.modelOptions);
+
+        expect(model.supportedPaymentOptions).to.deep.equal(['card', 'paypal']);
       });
 
       it('uses custom order of payment options', function () {
@@ -92,6 +103,28 @@ describe('DropinModel', function () {
         model = new DropinModel(this.modelOptions);
 
         expect(model.supportedPaymentOptions).to.deep.equal(['paypal', 'card']);
+      });
+
+      it('ignores duplicates', function () {
+        var model;
+
+        this.configuration.gatewayConfiguration.paypalEnabled = true;
+        this.modelOptions.merchantConfiguration.paypal = true;
+        this.modelOptions.merchantConfiguration.order = ['paypal', 'paypal', 'card'];
+
+        model = new DropinModel(this.modelOptions);
+
+        expect(model.supportedPaymentOptions).to.deep.equal(['paypal', 'card']);
+      });
+
+      it('throws an error when an unrecognized payment option is specified', function () {
+        this.configuration.gatewayConfiguration.paypalEnabled = true;
+        this.modelOptions.merchantConfiguration.paypal = true;
+        this.modelOptions.merchantConfiguration.order = ['foo', 'paypal', 'card'];
+
+        expect(function () {
+          new DropinModel(this.modelOptions); // eslint-disable-line no-new
+        }.bind(this)).to.throw('order: Invalid payment option specified.');
       });
     });
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -66,10 +66,10 @@ describe('DropinModel', function () {
         }.bind(this)).to.throw('No valid payment options available.');
       });
 
-      it('throws an error when order is an empty array', function () {
+      it('throws an error when paymentOptionPriority is an empty array', function () {
         this.configuration.gatewayConfiguration.paypalEnabled = true;
         this.modelOptions.merchantConfiguration.paypal = true;
-        this.modelOptions.merchantConfiguration.order = [];
+        this.modelOptions.merchantConfiguration.paymentOptionPriority = [];
 
         expect(function () {
           new DropinModel(this.modelOptions); // eslint-disable-line no-new
@@ -82,7 +82,7 @@ describe('DropinModel', function () {
         ]);
       });
 
-      it('supports cards and paypal and defaults to showing them in correct order', function () {
+      it('supports cards and paypal and defaults to showing them in correct paymentOptionPriority', function () {
         var model;
 
         this.configuration.gatewayConfiguration.paypalEnabled = true;
@@ -93,12 +93,12 @@ describe('DropinModel', function () {
         expect(model.supportedPaymentOptions).to.deep.equal(['card', 'paypal']);
       });
 
-      it('uses custom order of payment options', function () {
+      it('uses custom paymentOptionPriority of payment options', function () {
         var model;
 
         this.configuration.gatewayConfiguration.paypalEnabled = true;
         this.modelOptions.merchantConfiguration.paypal = true;
-        this.modelOptions.merchantConfiguration.order = ['paypal', 'card'];
+        this.modelOptions.merchantConfiguration.paymentOptionPriority = ['paypal', 'card'];
 
         model = new DropinModel(this.modelOptions);
 
@@ -110,7 +110,7 @@ describe('DropinModel', function () {
 
         this.configuration.gatewayConfiguration.paypalEnabled = true;
         this.modelOptions.merchantConfiguration.paypal = true;
-        this.modelOptions.merchantConfiguration.order = ['paypal', 'paypal', 'card'];
+        this.modelOptions.merchantConfiguration.paymentOptionPriority = ['paypal', 'paypal', 'card'];
 
         model = new DropinModel(this.modelOptions);
 
@@ -120,11 +120,11 @@ describe('DropinModel', function () {
       it('throws an error when an unrecognized payment option is specified', function () {
         this.configuration.gatewayConfiguration.paypalEnabled = true;
         this.modelOptions.merchantConfiguration.paypal = true;
-        this.modelOptions.merchantConfiguration.order = ['foo', 'paypal', 'card'];
+        this.modelOptions.merchantConfiguration.paymentOptionPriority = ['foo', 'paypal', 'card'];
 
         expect(function () {
           new DropinModel(this.modelOptions); // eslint-disable-line no-new
-        }.bind(this)).to.throw('order: Invalid payment option specified.');
+        }.bind(this)).to.throw('paymentOptionPriority: Invalid payment option specified.');
       });
     });
 


### PR DESCRIPTION
### Summary
Allow merchants to have Drop-in display payment options (`card`, `paypal`) in a specific order.

Payment options omitted from the list are not displayed to customers, so this can also be used as a way to exclude payment options from Drop-in on the client-side.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
