### PR TITLE
Fixes translation interpolation

### DIFF
--- a/src/html/main.html
+++ b/src/html/main.html
@@ -8,7 +8,7 @@
 
 <div class="braintree-dropin braintree-hidden">
   <div data-braintree-id="methods" class="braintree-methods">
-    <div data-braintree-id="methods-label" class="braintree-heading">{{payingWith}}
+    <div data-braintree-id="methods-label" class="braintree-heading">
     </div>
     <div data-braintree-id="methods-container">
     </div>

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  payingWith: 'Paying with',
+  payingWith: 'Paying with {{paymentSource}}',
   chooseAnotherWayToPay: 'Choose another way to pay',
   chooseAWayToPay: 'Choose a way to pay',
   otherWaysToPay: 'Other ways to pay',

--- a/src/views/payment-methods-view.js
+++ b/src/views/payment-methods-view.js
@@ -3,6 +3,11 @@
 var BaseView = require('./base-view');
 var PaymentMethodView = require('./payment-method-view');
 
+var PAYMENT_METHOD_TYPE_TO_TRANSLATION_STRING = {
+  CreditCard: 'Card',
+  PayPalAccount: 'PayPal'
+};
+
 function PaymentMethodsView() {
   BaseView.apply(this, arguments);
 
@@ -19,6 +24,7 @@ PaymentMethodsView.prototype._initialize = function () {
 
   this.views = [];
   this.container = this.getElementById('methods-container');
+  this._headingLabel = this.getElementById('methods-label');
 
   this.model.on('addPaymentMethod', this._addPaymentMethod.bind(this));
   this.model.on('changeActivePaymentMethod', this._changeActivePaymentMethodView.bind(this));
@@ -26,6 +32,13 @@ PaymentMethodsView.prototype._initialize = function () {
   for (i = paymentMethods.length - 1; i >= 0; i--) {
     this._addPaymentMethod(paymentMethods[i]);
   }
+};
+
+PaymentMethodsView.prototype._getPaymentMethodString = function () {
+  var stringKey = PAYMENT_METHOD_TYPE_TO_TRANSLATION_STRING[this.activeMethodView.paymentMethod.type];
+  var paymentMethodTypeString = this.strings[stringKey];
+
+  return this.strings.payingWith.replace('{{paymentSource}}', paymentMethodTypeString);
 };
 
 PaymentMethodsView.prototype._addPaymentMethod = function (paymentMethod) {
@@ -56,6 +69,7 @@ PaymentMethodsView.prototype._changeActivePaymentMethodView = function (paymentM
   for (i = 0; i < this.views.length; i++) {
     if (this.views[i].paymentMethod === paymentMethod) {
       this.activeMethodView = this.views[i];
+      this._headingLabel.textContent = this._getPaymentMethodString();
       break;
     }
   }

--- a/test/unit/views/payment-methods-view.js
+++ b/test/unit/views/payment-methods-view.js
@@ -52,7 +52,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientTokenWithCustomerID
         },
-        strings: {}
+        strings: strings
       });
 
       expect(paymentMethodsViews.views.length).to.equal(2);
@@ -115,7 +115,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientTokenWithCustomerID
         },
-        strings: {}
+        strings: strings
       });
 
       expect(paymentMethodsViews.views.length).to.equal(0);
@@ -140,7 +140,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientTokenWithCustomerID
         },
-        strings: {}
+        strings: strings
       });
 
       paymentMethodsViews._addPaymentMethod(fakePaymentMethod);
@@ -151,6 +151,36 @@ describe('PaymentMethodsView', function () {
       this.clock.tick(1001);
       expect(paymentMethodsViews.activeMethodView.element.className).to.contain('braintree-method--active');
       this.clock.restore();
+    });
+
+    it('updates the paying with label when the active payment method changes', function () {
+      var model, paymentMethodsViews;
+      var fakeCard = {type: 'CreditCard', details: {lastTwo: 22}};
+      var fakePayPal = {type: 'PayPalAccount', details: {email: 'buyer@braintreepayments.com'}};
+      var modelOptions = fake.modelOptions();
+
+      modelOptions.merchantConfiguration.authorization = fake.clientTokenWithCustomerID;
+      modelOptions.paymentMethods = [fakePayPal, fakeCard];
+      model = new DropinModel(modelOptions);
+      model.isGuestCheckout = false;
+
+      paymentMethodsViews = new PaymentMethodsView({
+        element: this.element,
+        model: model,
+        merchantConfiguration: {
+          authorization: fake.clientTokenWithCustomerID
+        },
+        strings: strings
+      });
+
+      paymentMethodsViews._addPaymentMethod(fakePayPal);
+      paymentMethodsViews._addPaymentMethod(fakeCard);
+
+      model.changeActivePaymentMethod(fakeCard);
+      expect(paymentMethodsViews.getElementById('methods-label').textContent).to.equal('Paying with Card');
+
+      model.changeActivePaymentMethod(fakePayPal);
+      expect(paymentMethodsViews.getElementById('methods-label').textContent).to.equal('Paying with PayPal');
     });
   });
 
@@ -185,7 +215,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientTokenWithCustomerID
         },
-        strings: {}
+        strings: strings
       });
 
       model.addPaymentMethod({foo: 'bar'});
@@ -208,7 +238,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientToken
         },
-        strings: {}
+        strings: strings
       });
 
       model.addPaymentMethod({foo: 'bar'});
@@ -230,7 +260,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientToken
         },
-        strings: {}
+        strings: strings
       });
 
       model.addPaymentMethod({foo: 'bar'});
@@ -256,7 +286,7 @@ describe('PaymentMethodsView', function () {
         merchantConfiguration: {
           authorization: fake.clientTokenWithCustomerID
         },
-        strings: {}
+        strings: strings
       });
 
       paymentMethodsViews.activeMethodView = fakeActiveMethodView;


### PR DESCRIPTION
Closes #104

### Summary
The payingWith English string did not include paymentSource. This adds it in and updates the heading whenever the payment method is changed.

### Checklist

- [ ] ~~Added a changelog entry~~ <- has Add translations in the next release
- [x] Ran unit tests
