### PR TITLE
Remove duplicate stylesheet by setting the id

### DIFF
--- a/src/dropin.js
+++ b/src/dropin.js
@@ -154,6 +154,7 @@ Dropin.prototype._injectStylesheet = function () {
   stylesheet.setAttribute('rel', 'stylesheet');
   stylesheet.setAttribute('type', 'text/css');
   stylesheet.setAttribute('href', stylesheetUrl);
+  stylesheet.setAttribute('id', constants.STYLESHEET_ID);
 
   if (head.firstChild) {
     head.insertBefore(stylesheet, head.firstChild);

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 
-<link rel="stylesheet" type="text/css" href="/web/dropin/dev/css/dropin.css">
+<link rel="stylesheet" type="text/css" href="/web/dropin/dev/css/dropin.css" id="braintree-dropin-stylesheet">
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
 <title>Drop-in demo</title>

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -34,8 +34,14 @@ describe('Dropin', function () {
   });
 
   afterEach(function () {
+    var stylesheet = document.getElementById(constants.STYLESHEET_ID);
+
     if (document.body.querySelector('#foo')) {
       document.body.removeChild(this.container);
+    }
+
+    if (stylesheet) {
+      stylesheet.parentNode.removeChild(stylesheet);
     }
   });
 
@@ -191,7 +197,29 @@ describe('Dropin', function () {
       var instance = new Dropin(this.dropinOptions);
 
       instance._initialize(function () {
-        expect(document.getElementById(constants.STYLESHEET_ID)).to.exist;
+        var stylesheet = document.getElementById(constants.STYLESHEET_ID);
+
+        expect(stylesheet).to.exist;
+        expect(stylesheet.href).to.match(/assets\.braintreegateway\.com/);
+
+        done();
+      });
+    });
+
+    it('does not inject stylesheet if it already exists on the page', function (done) {
+      var instance = new Dropin(this.dropinOptions);
+      var stylesheetOnPage = document.createElement('link');
+
+      stylesheetOnPage.id = constants.STYLESHEET_ID;
+      stylesheetOnPage.href = '/customer/dropin.css';
+
+      document.body.appendChild(stylesheetOnPage);
+
+      instance._initialize(function () {
+        var stylesheet = document.getElementById(constants.STYLESHEET_ID);
+
+        expect(stylesheet).to.exist;
+        expect(stylesheet.href).to.match(/\/customer\/dropin\.css/);
 
         done();
       });

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -7,6 +7,7 @@ var analytics = require('../../src/lib/analytics');
 var fake = require('../helpers/fake');
 var hostedFields = require('braintree-web/hosted-fields');
 var paypal = require('braintree-web/paypal');
+var constants = require('../../src/constants');
 
 describe('Dropin', function () {
   beforeEach(function () {
@@ -184,6 +185,16 @@ describe('Dropin', function () {
 
         done();
       }.bind(this));
+    });
+
+    it('injects stylesheet with correct id', function (done) {
+      var instance = new Dropin(this.dropinOptions);
+
+      instance._initialize(function () {
+        expect(document.getElementById(constants.STYLESHEET_ID)).to.exist;
+
+        done();
+      });
     });
 
     it('requests payment methods if a customerId is provided', function (done) {


### PR DESCRIPTION
### Summary
We were checking for the existence of an element with id
'braintree-dropin-stylesheet' but we failed to actually set the id
anywhere.

The test app was including both a local stylesheet and one from the
assets server. This fixes the issue by not including the assets server
stylesheet when the local one is already present.

### Checklist

- [x] Ran unit tests
