### PR TITLE
Sets npm_package_version from the package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,6 +143,8 @@ gulp.task('clean', function () {
 });
 
 gulp.task('build', function (done) {
+  process.env.npm_package_version = VERSION;
+
   runSequence(
   'clean',
   ['build:js', 'build:css', 'build:jsdoc', 'build:npm'],
@@ -154,7 +156,7 @@ function jsdoc(options, done) {
   var args = ['jsdoc', 'src'];
   var command = 'bash';
   var commandOption = '-c';
-  
+
   if (process.platform.indexOf('win')>=0) {
     command = 'cmd';
     commandOption = '/c';
@@ -220,6 +222,8 @@ gulp.task('development', [
 ]);
 
 gulp.task('watch', function () {
+  process.env.npm_package_version = VERSION;
+
   gulp.watch([config.src.js.watch, config.src.html.watch], ['build:js']);
   gulp.watch([config.src.css.watch], ['build:css']);
   gulp.watch([config.src.js.watch, config.jsdoc.watch], ['build:jsdoc']);


### PR DESCRIPTION
### Summary

Sets`npm_package_version` manually from the package.json [like we do in `braintree-web`](https://github.com/braintree/braintree-web/blob/master/gulpfile.js#L26) to avoid complications when we kick off the build from an app that overwrites `npm_package_version`.

 
