### PR TITLE
Remove unused closeFrame check in MainView

### DIFF
--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -119,10 +119,6 @@ MainView.prototype.getView = function (id) {
 };
 
 MainView.prototype.setPrimaryView = function (id) {
-  if (this.primaryView && this.primaryView.closeFrame) {
-    this.primaryView.closeFrame();
-  }
-
   this.element.className = prefixClass(id);
   this.primaryView = this.getView(id);
   this.model.changeActivePaymentView(id);

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -222,21 +222,6 @@ describe('MainView', function () {
       this.sandbox.stub(PayPalCheckout, 'create').yields(null, {});
     });
 
-    it('calls the close frame function of the primary view if one exists', function () {
-      var mainView;
-
-      PayPalView.prototype.closeFrame = this.sandbox.stub();
-
-      mainView = new MainView(this.mainViewOptions);
-
-      mainView.setPrimaryView(PayPalView.ID);
-      mainView.setPrimaryView(PaymentOptionsView.ID);
-
-      expect(PayPalView.prototype.closeFrame).to.have.been.calledOnce;
-
-      delete PayPalView.prototype.closeFrame;
-    });
-
     it('clears any errors', function () {
       var mainView = new MainView(this.mainViewOptions);
 


### PR DESCRIPTION
### Summary

When we used the `paypal` component we checked if we needed to close the PayPal frame when we changed views. The checkout.js overlay now handles that for us. 

### Checklist

~- [ ] Added a changelog entry~
- [x] Ran unit tests
