### PR TITLE
Use locale in PayPal Checkout

### DIFF
--- a/src/views/payment-sheet-views/paypal-view.js
+++ b/src/views/payment-sheet-views/paypal-view.js
@@ -35,7 +35,7 @@ PayPalView.prototype._initialize = function () {
 
   btPaypal.create({client: this.client}, function (err, paypalInstance) {
     var paypalCheckoutConfiguration;
-    var merchantConfiguration = self.model.merchantConfiguration.paypal;
+    var merchantConfiguration = self.model.merchantConfiguration;
     var environment = self.client.getConfiguration().gatewayConfiguration.environment === 'production' ? 'production' : 'sandbox';
 
     if (err) {
@@ -51,7 +51,7 @@ PayPalView.prototype._initialize = function () {
     paypalCheckoutConfiguration = {
       env: environment,
       payment: function () {
-        return paypalInstance.createPayment(merchantConfiguration).catch(reportError);
+        return paypalInstance.createPayment(merchantConfiguration.paypal).catch(reportError);
       },
       onAuthorize: function (data) {
         return paypalInstance.tokenizePayment(data).then(function (tokenizePayload) {
@@ -60,6 +60,10 @@ PayPalView.prototype._initialize = function () {
       },
       onError: reportError
     };
+
+    if (merchantConfiguration.locale) {
+      paypalCheckoutConfiguration.locale = merchantConfiguration.locale;
+    }
 
     paypal.Button.render(paypalCheckoutConfiguration, '[data-braintree-id="paypal-button"]').then(function () {
       self.model.asyncDependencyReady();

--- a/src/views/payment-sheet-views/paypal-view.js
+++ b/src/views/payment-sheet-views/paypal-view.js
@@ -34,8 +34,8 @@ PayPalView.prototype._initialize = function () {
   this.model.asyncDependencyStarting();
 
   btPaypal.create({client: this.client}, function (err, paypalInstance) {
-    var paypalCheckoutConfig;
-    var merchantConfig = self.model.merchantConfiguration.paypal;
+    var paypalCheckoutConfiguration;
+    var merchantConfiguration = self.model.merchantConfiguration.paypal;
     var environment = self.client.getConfiguration().gatewayConfiguration.environment === 'production' ? 'production' : 'sandbox';
 
     if (err) {
@@ -48,10 +48,10 @@ PayPalView.prototype._initialize = function () {
 
     self.paypalInstance = paypalInstance;
 
-    paypalCheckoutConfig = {
+    paypalCheckoutConfiguration = {
       env: environment,
       payment: function () {
-        return paypalInstance.createPayment(merchantConfig).catch(reportError);
+        return paypalInstance.createPayment(merchantConfiguration).catch(reportError);
       },
       onAuthorize: function (data) {
         return paypalInstance.tokenizePayment(data).then(function (tokenizePayload) {
@@ -61,7 +61,7 @@ PayPalView.prototype._initialize = function () {
       onError: reportError
     };
 
-    paypal.Button.render(paypalCheckoutConfig, '[data-braintree-id="paypal-button"]').then(function () {
+    paypal.Button.render(paypalCheckoutConfiguration, '[data-braintree-id="paypal-button"]').then(function () {
       self.model.asyncDependencyReady();
     });
   });

--- a/test/unit/views/payment-sheet-views/paypal-view.js
+++ b/test/unit/views/payment-sheet-views/paypal-view.js
@@ -149,6 +149,21 @@ describe('PayPalView', function () {
       }.bind(this));
     });
 
+    it('calls paypal.Button.render with a locale if one is present', function (done) {
+      var fakeLocaleCode = 'fake_LOCALE';
+      var configurationObject = {locale: fakeLocaleCode};
+
+      this.model.merchantConfiguration.locale = fakeLocaleCode;
+
+      new PayPalView(this.paypalViewOptions);
+
+      waitForInitialize(function () {
+        expect(paypal.Button.render).to.be.calledOnce;
+        expect(paypal.Button.render).to.be.calledWith(this.sandbox.match(configurationObject));
+        done();
+      }.bind(this));
+    });
+
     it('sets paypal-checkout.js environment to production when gatewayConfiguration is production', function (done) {
       this.configuration.gatewayConfiguration.environment = 'production';
       new PayPalView(this.paypalViewOptions);
@@ -173,7 +188,7 @@ describe('PayPalView', function () {
       });
     });
 
-    it('calls payalInstance.createPayment with merchant config when checkout.js payment function is called', function (done) {
+    it('calls paypalInstance.createPayment with merchant config when checkout.js payment function is called', function (done) {
       var paypalInstance = this.paypalInstance;
       var model = this.model;
 


### PR DESCRIPTION
### Summary

We weren't using the locale from the merchant configuration in PayPal Checkout; this fixes that.

### Checklist

~Added a changelog entry~
- [x] Ran unit tests
