### PR TITLE
Remove close frame as intended in PR #117

### DIFF
--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -121,10 +121,6 @@ MainView.prototype.getView = function (id) {
 };
 
 MainView.prototype.setPrimaryView = function (id, secondaryViewId) {
-  if (this.primaryView && this.primaryView.closeFrame) {
-    this.primaryView.closeFrame();
-  }
-
   setTimeout(function () {
     this.element.className = prefixShowClass(id);
     if (secondaryViewId) {


### PR DESCRIPTION
### Summary
[PR'd](https://github.com/braintree/braintree-web-drop-in/pull/117) a change to remove a close frame check that got undid in a merge. This _actually_ removes it.

### Checklist

- [x] Ran unit tests
