### PR TITLE
Add CSS section to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,6 +31,16 @@ dist
 
 **Note:** If you are developing on a Windows machine, you will need to run your command prompt as an administrator so the symlinking step succeeds.
 
+## CSS
+
+In sandbox and production environments, Drop-in injects a stylesheet onto the page retrieved from https://assets.braintreegateway.com/web/dropin/<VERSION>/css/dropin.css.
+
+To develop in a sandbox environment, include locally built CSS on the page that will override the hosted stylesheet:
+
+```html
+<link rel="stylesheet" type="text/css" href="/path/to/local/dropin.css" id="braintree-dropin-stylesheet">
+```
+
 ## Testing
 
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ dist
 
 In sandbox and production environments, Drop-in injects a stylesheet onto the page retrieved from https://assets.braintreegateway.com/web/dropin/<VERSION>/css/dropin.css.
 
-To develop in a sandbox environment, include locally built CSS on the page that will override the hosted stylesheet:
+When developing, you can include a locally built CSS file on the page that will override the hosted stylesheet by giving it the id `braintree-dropin-stylesheet`:
 
 ```html
 <link rel="stylesheet" type="text/css" href="/path/to/local/dropin.css" id="braintree-dropin-stylesheet">


### PR DESCRIPTION
### Summary

Adds instructions about how to develop using non-hosted CSS, which is required if trying to make changes to CSS using sandbox authorization. 

In lieu of https://github.com/braintree/braintree-web-drop-in/pull/112