### PR TITLE
Fix transition to not add multiple cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ unreleased
 - Improve loading transition
 - Add full support for IE 9 and 10
 - Add support for PayPal Credit
+- Fix bug where adding a vaulted payment method would duplicate previously added payment methods
 
 1.0.0-beta.6
 ------------

--- a/src/lib/transition-helper.js
+++ b/src/lib/transition-helper.js
@@ -8,11 +8,14 @@ function onTransitionEnd(element, propertyName, callback) {
     return;
   }
 
-  element.addEventListener('transitionend', function (event) {
+  function transitionEventListener(event) {
     if (event.propertyName === propertyName) {
+      element.removeEventListener('transitionend', transitionEventListener);
       callback();
     }
-  });
+  }
+
+  element.addEventListener('transitionend', transitionEventListener);
 }
 
 module.exports = {

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -170,7 +170,6 @@ CardView.prototype.tokenize = function (callback) {
           self.model.addPaymentMethod(payload);
           callback(null, payload);
           classlist.remove(self.element, 'braintree-sheet--tokenized');
-          self.element.removeEventListener('transitionend', transitionCallback);
         }, 0);
       };
 

--- a/test/unit/lib/unit/transition-helper.js
+++ b/test/unit/lib/unit/transition-helper.js
@@ -31,6 +31,21 @@ describe('onTransitionEnd', function () {
     });
   });
 
+  it('removes event listener after callback is called', function (done) {
+    var element = document.createElement('div');
+
+    this.sandbox.stub(element, 'addEventListener').yields(this.fakeEvent);
+    this.sandbox.stub(element, 'removeEventListener');
+    this.sandbox.stub(browserDetection, 'isIe9').returns(false);
+
+    onTransitionEnd(element, this.fakePropertyName, function () {
+      expect(element.removeEventListener).to.have.been.calledOnce;
+      expect(element.addEventListener).to.have.been.calledWith('transitionend', this.sandbox.match.func);
+
+      done();
+    }.bind(this));
+  });
+
   it('does not call callback after onTransitionEnd end when the event propertyName does not match', function () {
     var callbackSpy = this.sandbox.spy();
     var element = document.createElement('div');


### PR DESCRIPTION
### Summary

Whenever you added more than one vaulted card, the previously added cards would start to multiply. This was because the listener transition callback was not actually being cleaned up correctly.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
