### PR TITLE
Add tab navigation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ unreleased
 - Add full support for IE 9 and 10
 - Add support for PayPal Credit
 - Fix bug where adding a vaulted payment method would duplicate previously added payment methods
+- Add support for tab navigation
 
 1.0.0-beta.6
 ------------

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -157,7 +157,7 @@
     <div data-braintree-id="other-ways-to-pay" class="braintree-heading">{{otherWaysToPay}}</div>
   </div>
 
-  <div data-braintree-id="toggle" class="braintree-toggle braintree-hidden">
+  <div data-braintree-id="toggle" class="braintree-toggle braintree-hidden" tabindex="0">
     <span>{{chooseAnotherWayToPay}}</span>
   </div>
 </div>

--- a/src/lib/add-selection-event-handler.js
+++ b/src/lib/add-selection-event-handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpEventHandlers(element, func) {
+function addSelectionEventHandler(element, func) {
   element.addEventListener('click', func);
   element.addEventListener('keyup', function (event) {
     if (event.keyCode === 13) {
@@ -9,4 +9,4 @@ function setUpEventHandlers(element, func) {
   });
 }
 
-module.exports = setUpEventHandlers;
+module.exports = addSelectionEventHandler;

--- a/src/lib/set-up-event-handlers.js
+++ b/src/lib/set-up-event-handlers.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function setUpEventHandlers(element, func) {
+  element.addEventListener('click', func);
+  element.addEventListener('keyup', function (event) {
+    if (event.keyCode === 13) {
+      func();
+    }
+  });
+}
+
+module.exports = setUpEventHandlers;

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -7,7 +7,7 @@ var classlist = require('../lib/classlist');
 var sheetViews = require('./payment-sheet-views');
 var PaymentMethodsView = require('./payment-methods-view');
 var PaymentOptionsView = require('./payment-options-view');
-var setUpEventHandlers = require('../lib/set-up-event-handlers');
+var addSelectionEventHandler = require('../lib/add-selection-event-handler');
 var supportsFlexbox = require('../lib/supports-flexbox');
 var transitionHelper = require('../lib/transition-helper');
 
@@ -74,7 +74,7 @@ MainView.prototype._initialize = function () {
   });
   this.addView(this.paymentMethodsViews);
 
-  setUpEventHandlers(this.toggle, this.toggleAdditionalOptions.bind(this));
+  addSelectionEventHandler(this.toggle, this.toggleAdditionalOptions.bind(this));
 
   this.model.on('changeActivePaymentMethod', function () {
     this.setPrimaryView(PaymentMethodsView.ID);

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -7,6 +7,7 @@ var classlist = require('../lib/classlist');
 var sheetViews = require('./payment-sheet-views');
 var PaymentMethodsView = require('./payment-methods-view');
 var PaymentOptionsView = require('./payment-options-view');
+var setUpEventHandlers = require('../lib/set-up-event-handlers');
 var supportsFlexbox = require('../lib/supports-flexbox');
 var transitionHelper = require('../lib/transition-helper');
 
@@ -73,7 +74,7 @@ MainView.prototype._initialize = function () {
   });
   this.addView(this.paymentMethodsViews);
 
-  this.toggle.addEventListener('click', this.toggleAdditionalOptions.bind(this));
+  setUpEventHandlers(this.toggle, this.toggleAdditionalOptions.bind(this));
 
   this.model.on('changeActivePaymentMethod', function () {
     this.setPrimaryView(PaymentMethodsView.ID);

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -4,6 +4,7 @@ var BaseView = require('./base-view');
 var classlist = require('../lib/classlist');
 var constants = require('../constants');
 var fs = require('fs');
+var setUpEventHandlers = require('../lib/set-up-event-handlers');
 
 var paymentMethodHTML = fs.readFileSync(__dirname + '/../html/payment-method.html', 'utf8');
 
@@ -24,8 +25,9 @@ PaymentMethodView.prototype._initialize = function () {
 
   this.element = document.createElement('div');
   this.element.className = 'braintree-method';
+  this.element.setAttribute('tabindex', '0');
 
-  this.element.addEventListener('click', function () {
+  setUpEventHandlers(this.element, function () {
     this.model.changeActivePaymentMethod(this.paymentMethod);
   }.bind(this));
 

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -4,7 +4,7 @@ var BaseView = require('./base-view');
 var classlist = require('../lib/classlist');
 var constants = require('../constants');
 var fs = require('fs');
-var setUpEventHandlers = require('../lib/set-up-event-handlers');
+var addSelectionEventHandler = require('../lib/add-selection-event-handler');
 
 var paymentMethodHTML = fs.readFileSync(__dirname + '/../html/payment-method.html', 'utf8');
 
@@ -27,7 +27,7 @@ PaymentMethodView.prototype._initialize = function () {
   this.element.className = 'braintree-method';
   this.element.setAttribute('tabindex', '0');
 
-  setUpEventHandlers(this.element, function () {
+  addSelectionEventHandler(this.element, function () {
     this.model.changeActivePaymentMethod(this.paymentMethod);
   }.bind(this));
 

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var analytics = require('../lib/analytics');
-var setUpEventHandlers = require('../lib/set-up-event-handlers');
+var addSelectionEventHandler = require('../lib/add-selection-event-handler');
 var BaseView = require('./base-view');
 var fs = require('fs');
 var paymentOptionIDs = require('../constants').paymentOptionIDs;
@@ -61,7 +61,7 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
 
   div.innerHTML = html;
 
-  setUpEventHandlers(div, clickHandler);
+  addSelectionEventHandler(div, clickHandler);
 
   this.container.appendChild(div);
   this.elements[paymentOptionID] = {

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var analytics = require('../lib/analytics');
+var setUpEventHandlers = require('../lib/set-up-event-handlers');
 var BaseView = require('./base-view');
 var fs = require('fs');
 var paymentOptionIDs = require('../constants').paymentOptionIDs;
@@ -35,6 +36,7 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
   }.bind(this);
 
   div.className = 'braintree-option braintree-option__' + paymentOptionID;
+  div.setAttribute('tabindex', '0');
 
   switch (paymentOptionID) {
     case paymentOptionIDs.card:
@@ -59,7 +61,8 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
 
   div.innerHTML = html;
 
-  div.addEventListener('click', clickHandler);
+  setUpEventHandlers(div, clickHandler);
+
   this.container.appendChild(div);
   this.elements[paymentOptionID] = {
     div: div,

--- a/test/unit/lib/unit/set-up-click-handler.js
+++ b/test/unit/lib/unit/set-up-click-handler.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var setUpEventHandlers = require('../../../../src/lib/set-up-event-handlers');
+var addSelectionEventHandler = require('../../../../src/lib/add-selection-event-handler');
 
-describe('setUpEventHandlers', function () {
+describe('addSelectionEventHandler', function () {
   it('adds an event listener for click', function () {
     var event = {};
     var element = {
@@ -10,7 +10,7 @@ describe('setUpEventHandlers', function () {
     };
     var func = this.sandbox.stub();
 
-    setUpEventHandlers(element, func);
+    addSelectionEventHandler(element, func);
 
     expect(element.addEventListener).to.be.calledWith('click', func);
     expect(func).to.be.calledWith(event);
@@ -22,7 +22,7 @@ describe('setUpEventHandlers', function () {
     };
     var func = this.sandbox.stub();
 
-    setUpEventHandlers(element, func);
+    addSelectionEventHandler(element, func);
 
     expect(element.addEventListener).to.be.calledWith('keyup', this.sandbox.match.func);
   });
@@ -36,7 +36,7 @@ describe('setUpEventHandlers', function () {
 
     element.addEventListener.withArgs('keyup').yields(event);
 
-    setUpEventHandlers(element, func);
+    addSelectionEventHandler(element, func);
 
     expect(func).to.be.called;
   });
@@ -50,7 +50,7 @@ describe('setUpEventHandlers', function () {
 
     element.addEventListener.withArgs('keyup').yields(event);
 
-    setUpEventHandlers(element, func);
+    addSelectionEventHandler(element, func);
 
     expect(func).to.not.be.called;
   });

--- a/test/unit/lib/unit/set-up-click-handler.js
+++ b/test/unit/lib/unit/set-up-click-handler.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var setUpEventHandlers = require('../../../../src/lib/set-up-event-handlers');
+
+describe('setUpEventHandlers', function () {
+  it('adds an event listener for click', function () {
+    var event = {};
+    var element = {
+      addEventListener: this.sandbox.stub().yields(event)
+    };
+    var func = this.sandbox.stub();
+
+    setUpEventHandlers(element, func);
+
+    expect(element.addEventListener).to.be.calledWith('click', func);
+    expect(func).to.be.calledWith(event);
+  });
+
+  it('adds an event listener for keyup', function () {
+    var element = {
+      addEventListener: this.sandbox.stub()
+    };
+    var func = this.sandbox.stub();
+
+    setUpEventHandlers(element, func);
+
+    expect(element.addEventListener).to.be.calledWith('keyup', this.sandbox.match.func);
+  });
+
+  it('calls handler for keyup when key is enter', function () {
+    var event = {keyCode: 13};
+    var element = {
+      addEventListener: this.sandbox.stub()
+    };
+    var func = this.sandbox.stub();
+
+    element.addEventListener.withArgs('keyup').yields(event);
+
+    setUpEventHandlers(element, func);
+
+    expect(func).to.be.called;
+  });
+
+  it('does not call handler for keyup when key is not enter', function () {
+    var event = {keyCode: 26};
+    var element = {
+      addEventListener: this.sandbox.stub()
+    };
+    var func = this.sandbox.stub();
+
+    element.addEventListener.withArgs('keyup').yields(event);
+
+    setUpEventHandlers(element, func);
+
+    expect(func).to.not.be.called;
+  });
+});


### PR DESCRIPTION
### Summary

Adds support for tabbed navigation in drop-in.

*Note:* The PayPal buttons can be tabbed to and accessed by pressing enter, but they will not be highlighted. A change needs to be made in checkout.js for that to work.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
