### PR TITLE
Set PayPal button to be translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ unreleased
 - Add support for PayPal Credit
 - Fix bug where adding a vaulted payment method would duplicate previously added payment methods
 - Add support for tab navigation
+- Fix bug where PayPal button was not being translated
 
 1.0.0-beta.6
 ------------

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -51,6 +51,7 @@ BasePayPalView.prototype._initialize = function (isCredit) {
     self.paypalConfiguration.offerCredit = Boolean(isCredit);
     checkoutJSConfiguration = {
       env: environment,
+      locale: locale,
       payment: function () {
         return paypalInstance.createPayment(self.paypalConfiguration).catch(reportError);
       },

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -200,6 +200,23 @@ describe('BasePayPalView', function () {
       view._initialize();
     });
 
+    it('calls paypal.Button.render with a locale if one is provided', function (done) {
+      var fakeLocaleCode = 'fake_LOCALE';
+      var model = this.model;
+      var view = this.view;
+
+      model.merchantConfiguration.locale = fakeLocaleCode;
+
+      view._initialize();
+
+      waitForInitialize(function () {
+        expect(paypal.Button.render).to.be.calledWithMatch({
+          locale: 'fake_LOCALE'
+        });
+        done();
+      });
+    });
+
     it('reports errors from createPayment', function (done) {
       var model = this.model;
       var error = new Error('create payment error');


### PR DESCRIPTION
closes #134

### Summary

We weren't passing in the locale to the `paypal.Button.render` function, so while the popup was still being translated through the `createPayment` call, the button itself was not.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
