### PR TITLE
Increase retries around paypal tests

### DIFF
--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -92,7 +92,7 @@ describe "Drop-in" do
       expect(page).to have_content("Visa")
     end
 
-    it "PayPal" do
+    it "PayPal", :paypal do
       visit "http://#{HOSTNAME}:#{PORT}"
 
       click_option("paypal")
@@ -107,7 +107,7 @@ describe "Drop-in" do
       expect(page).to have_content(ENV["PAYPAL_USERNAME"])
     end
 
-    it "PayPal Credit" do
+    it "PayPal Credit", :paypal do
       visit "http://#{HOSTNAME}:#{PORT}"
 
       click_option("paypalCredit")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,10 @@ RSpec.configure do |config|
     c.run_with_retry(retry: 2)
   end
 
+  config.around(:each, :paypal) do |c|
+    c.run_with_retry(retry: 4, retry_wait: 4)
+  end
+
   if ParallelTests.first_process?
     config.before(:suite) do
       download_sauce_connect


### PR DESCRIPTION
### Summary

Sets PayPal tests to retry 4 times instead of 2.

### Checklist

- [ ] ~~Added a changelog entry~~
- [ ] ~~Ran unit tests~~
