### PR TITLE
Prevent unusable saved payment methods from being displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ unreleased
 - Auto focus the number input when selecting the card view
 - Add events for `paymentMethodRequestable` and `noPaymentMethodRequestable`
 - Fix bug where PayPal button was not being translated
+- Fix bug where unusable payment methods would be displayed if saved in the vault
 
 1.0.0-beta.6
 ------------

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,8 @@ module.exports = {
   },
   paymentMethodTypes: {
     card: 'CreditCard',
-    paypal: 'PayPalAccount'
+    paypal: 'PayPalAccount',
+    paypalCredit: 'PayPalAccount'
   },
   analyticsKinds: {
     CreditCard: 'card',

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -300,8 +300,8 @@ describe('Dropin', function () {
       var instance;
       var fakePaymentMethod = {
         nonce: 'nonce',
-        details: {},
-        type: 'type',
+        details: {lastTwo: '11'},
+        type: 'CreditCard',
         garbage: 'garbage'
       };
       var paymentMethodsPayload = {paymentMethods: [fakePaymentMethod]};
@@ -323,8 +323,8 @@ describe('Dropin', function () {
         var existingPaymentMethod = instance._model.getPaymentMethods()[0];
 
         expect(existingPaymentMethod.nonce).to.equal('nonce');
-        expect(existingPaymentMethod.details).to.deep.equal({});
-        expect(existingPaymentMethod.type).to.equal('type');
+        expect(existingPaymentMethod.details).to.deep.equal({lastTwo: '11'});
+        expect(existingPaymentMethod.type).to.equal('CreditCard');
         expect(existingPaymentMethod.garbage).to.not.exist;
         done();
       });

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -103,7 +103,7 @@ describe('MainView', function () {
 
         element.innerHTML = templateHTML;
 
-        modelOptions.paymentMethods = [{foo: 'bar'}, {baz: 'qux'}];
+        modelOptions.paymentMethods = [{type: 'CreditCard', details: {lastTwo: '11'}}, {type: 'PayPalAccount'}];
         this.model = new DropinModel(modelOptions);
         this.model.supportedPaymentOptions = ['card', 'paypal'];
 
@@ -127,7 +127,7 @@ describe('MainView', function () {
 
         new MainView(this.mainViewOptions); // eslint-disable-line no-new
 
-        expect(this.model.changeActivePaymentMethod).to.have.been.calledWith({foo: 'bar'});
+        expect(this.model.changeActivePaymentMethod).to.have.been.calledWith({type: 'CreditCard', details: {lastTwo: '11'}});
       });
 
       it('sets the PaymentMethodsView as the primary view', function () {
@@ -720,7 +720,7 @@ describe('MainView', function () {
         beforeEach(function () {
           var modelOptions = fake.modelOptions();
 
-          modelOptions.paymentMethods = [{foo: 'bar'}];
+          modelOptions.paymentMethods = [{type: 'CreditCard', details: {lastTwo: '11'}}];
 
           this.mainViewOptions.model = new DropinModel(modelOptions);
           this.mainViewOptions.model.supportedPaymentOptions = ['card', 'paypal'];

--- a/test/unit/views/payment-methods-view.js
+++ b/test/unit/views/payment-methods-view.js
@@ -32,7 +32,7 @@ describe('PaymentMethodsView', function () {
       this.element.innerHTML = mainHTML;
     });
 
-    it('adds all vaulted payment methods', function () {
+    it('adds supported vaulted payment methods', function () {
       var model, paymentMethodsViews;
       var modelOptions = fake.modelOptions();
 
@@ -43,13 +43,15 @@ describe('PaymentMethodsView', function () {
           gatewayConfiguration: fake.configuration().gatewayConfiguration
         };
       };
-      modelOptions.paymentMethods = [{foo: 'bar'}, {baz: 'qux'}];
+      modelOptions.paymentMethods = [{type: 'CreditCard', details: {lastTwo: '11'}}, {type: 'PayPalAccount', details: {email: 'wow@example.com'}}, {type: 'UnsupportedPaymentMethod'}];
+      modelOptions.merchantConfiguration.paypal = {flow: 'vault'};
 
       model = new DropinModel(modelOptions);
       paymentMethodsViews = new PaymentMethodsView({
         element: this.element,
         model: model,
         merchantConfiguration: {
+          paypal: modelOptions.merchantConfiguration.paypal,
           authorization: fake.clientTokenWithCustomerID
         },
         strings: strings
@@ -62,7 +64,7 @@ describe('PaymentMethodsView', function () {
     it('puts default payment method as first item in list', function () {
       var firstChildLabel, model, paymentMethodsViews;
       var creditCard = {
-        details: {type: 'Visa'},
+        details: {cardType: 'Visa'},
         type: 'CreditCard'
       };
       var paypalAccount = {
@@ -79,14 +81,13 @@ describe('PaymentMethodsView', function () {
         };
       };
       modelOptions.paymentMethods = [paypalAccount, creditCard];
+      modelOptions.merchantConfiguration.paypal = {flow: 'vault'};
 
       model = new DropinModel(modelOptions);
       paymentMethodsViews = new PaymentMethodsView({
         element: this.element,
         model: model,
-        merchantConfiguration: {
-          authorization: fake.clientTokenWithCustomerID
-        },
+        merchantConfiguration: modelOptions.merchantConfiguration,
         strings: strings
       });
 
@@ -190,7 +191,10 @@ describe('PaymentMethodsView', function () {
 
       div.innerHTML = mainHTML;
       this.element = div.querySelector('.braintree-dropin');
-      this.fakePaymentMethod = {bax: 'qux'};
+      this.fakePaymentMethod = {
+        type: 'CreditCard',
+        details: {lastTwo: '11'}
+      };
     });
 
     it('does not remove other payment methods in non-guest checkout', function () {


### PR DESCRIPTION
### Summary

If a customer has a saved Android Pay, Apple Pay, Coinbase, etc, the nonce will still be displayed. In addition, if PayPal is disabled in drop-in, but a customer has a saved paypal account, it will still render the PayPal account as a saved payment method.

This PR fixes both cases.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
