### PR TITLE
Set margin for hosted-fields iframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ unreleased
 - Add events for `paymentMethodRequestable` and `noPaymentMethodRequestable`
 - Fix bug where PayPal button was not being translated
 - Fix bug where unusable payment methods would be displayed if saved in the vault
+- Fix styling bug where hosted fields iframe margin style could be overwritten
 
 1.0.0-beta.6
 ------------

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -458,6 +458,10 @@ $loader-scale-duration: 300ms;
    ========================================================================= */
 .braintree-form__hosted-field {
   transition: border-color 100ms;
+
+  iframe {
+    margin: auto;
+  }
 }
 
 .braintree-sheet__content--form {


### PR DESCRIPTION
### Summary

Applies margin styling to hosted fields iframes.

Fixes #124 

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
