### PR TITLE
Attempt to make paypal tests less flaky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ unreleased
 ----------
 - Use PayPal Checkout for PayPal View
 - Use version 3.14.0 of braintree-web
-- Use version 4.0.60 of paypal-checkout
+- Use version 4.0.65 of paypal-checkout
 - Improve loading transition
 - Add full support for IE 9 and 10
 - Add support for PayPal Credit

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "braintree-web": "3.14.0",
     "browser-detection": "braintree/browser-detection#1.1.0",
-    "paypal-checkout": "4.0.60",
+    "paypal-checkout": "4.0.65",
     "promise-polyfill": "6.0.2"
   },
   "browserify": {

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -10,6 +10,61 @@ describe "Drop-in" do
   include DropIn
   include PayPal
 
+  describe "tokenizes" do
+    it "a card" do
+      visit "http://#{HOSTNAME}:#{PORT}"
+
+      click_option("card")
+      hosted_field_send_input("number", "4111111111111111")
+      hosted_field_send_input("expirationDate", "1019")
+      hosted_field_send_input("cvv", "123")
+
+      submit_pay
+
+      expect(find(".braintree-heading")).to have_content("Paying with")
+
+      # Drop-in Details
+      expect(page).to have_content("Ending in ••11")
+
+      # Nonce Details
+      expect(page).to have_content("CreditCard")
+      expect(page).to have_content("ending in 11")
+      expect(page).to have_content("Visa")
+    end
+
+    it "PayPal", :paypal do
+      visit "http://#{HOSTNAME}:#{PORT}"
+
+      click_option("paypal")
+
+      open_popup_and_complete_login
+
+      submit_pay
+
+      expect(find(".braintree-heading")).to have_content("Paying with PayPal")
+
+      expect(page).to have_content("PayPalAccount")
+      expect(page).to have_content(ENV["PAYPAL_USERNAME"])
+    end
+
+    it "PayPal Credit", :paypal do
+      visit "http://#{HOSTNAME}:#{PORT}"
+
+      click_option("paypalCredit")
+
+      open_popup_and_complete_login do
+        expect(page).to have_content("PayPal Credit");
+      end
+
+      submit_pay
+
+      expect(find(".braintree-heading")).to have_content("Paying with PayPal")
+
+      expect(page).to have_content("PayPalAccount")
+      expect(page).to have_content(ENV["PAYPAL_USERNAME"])
+    end
+  end
+
   describe "setup" do
     it "requires a selector" do
       visit "http://#{HOSTNAME}:#{PORT}?selector=null"
@@ -120,61 +175,6 @@ describe "Drop-in" do
       find('.braintree-toggle').click
 
       expect(page).to have_button('Pay', disabled: false)
-    end
-  end
-
-  describe "tokenizes" do
-    it "a card" do
-      visit "http://#{HOSTNAME}:#{PORT}"
-
-      click_option("card")
-      hosted_field_send_input("number", "4111111111111111")
-      hosted_field_send_input("expirationDate", "1019")
-      hosted_field_send_input("cvv", "123")
-
-      submit_pay
-
-      expect(find(".braintree-heading")).to have_content("Paying with")
-
-      # Drop-in Details
-      expect(page).to have_content("Ending in ••11")
-
-      # Nonce Details
-      expect(page).to have_content("CreditCard")
-      expect(page).to have_content("ending in 11")
-      expect(page).to have_content("Visa")
-    end
-
-    it "PayPal", :paypal do
-      visit "http://#{HOSTNAME}:#{PORT}"
-
-      click_option("paypal")
-
-      open_popup_and_complete_login
-
-      submit_pay
-
-      expect(find(".braintree-heading")).to have_content("Paying with PayPal")
-
-      expect(page).to have_content("PayPalAccount")
-      expect(page).to have_content(ENV["PAYPAL_USERNAME"])
-    end
-
-    it "PayPal Credit", :paypal do
-      visit "http://#{HOSTNAME}:#{PORT}"
-
-      click_option("paypalCredit")
-
-      open_popup_and_complete_login do
-        expect(page).to have_content("PayPal Credit");
-      end
-
-      submit_pay
-
-      expect(find(".braintree-heading")).to have_content("Paying with PayPal")
-
-      expect(page).to have_content("PayPalAccount")
-      expect(page).to have_content(ENV["PAYPAL_USERNAME"])
     end
   end
 end

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -65,6 +65,59 @@ describe "Drop-in" do
     end
   end
 
+  describe "events" do
+    it "disable and enable submit button on credit card validity" do
+      visit "http://#{HOSTNAME}:#{PORT}"
+
+      click_option("card")
+
+      expect(page).to have_button('Pay', disabled: true)
+
+      # Put in valid state
+      hosted_field_send_input("number", "4111111111111111")
+      hosted_field_send_input("expirationDate", "1019")
+      hosted_field_send_input("cvv", "123")
+
+      expect(page).to have_button('Pay', disabled: false)
+
+      # Put in invalid state
+      hosted_field_send_input("expirationDate", :backspace)
+      hosted_field_send_input("expirationDate", "2")
+
+      expect(page).to have_button('Pay', disabled: true)
+
+      # Put in valid state again
+      hosted_field_send_input("expirationDate", :backspace)
+      hosted_field_send_input("expirationDate", "9")
+
+      expect(page).to have_button('Pay', disabled: false)
+    end
+
+    it "enable submit button on PayPal authorization", :paypal do
+      visit "http://#{HOSTNAME}:#{PORT}"
+
+      click_option("paypal")
+
+      expect(page).to have_button('Pay', disabled: true)
+
+      open_popup_and_complete_login
+
+      expect(page).to have_button('Pay', disabled: false)
+
+      find('.braintree-toggle').click
+
+      expect(page).to have_button('Pay', disabled: false)
+
+      click_option("paypal")
+
+      expect(page).to have_button('Pay', disabled: true)
+
+      find('.braintree-toggle').click
+
+      expect(page).to have_button('Pay', disabled: false)
+    end
+  end
+
   describe "setup" do
     it "requires a selector" do
       visit "http://#{HOSTNAME}:#{PORT}?selector=null"
@@ -122,59 +175,6 @@ describe "Drop-in" do
       visit URI.encode("http://#{HOSTNAME}:#{PORT}?paymentOptionPriority=#{options}")
 
       expect(find("#error")).to have_content("paymentOptionPriority: Invalid payment option specified.")
-    end
-  end
-
-  describe "events" do
-    it "disable and enable submit button on credit card validity" do
-      visit "http://#{HOSTNAME}:#{PORT}"
-
-      click_option("card")
-
-      expect(page).to have_button('Pay', disabled: true)
-
-      # Put in valid state
-      hosted_field_send_input("number", "4111111111111111")
-      hosted_field_send_input("expirationDate", "1019")
-      hosted_field_send_input("cvv", "123")
-
-      expect(page).to have_button('Pay', disabled: false)
-
-      # Put in invalid state
-      hosted_field_send_input("expirationDate", :backspace)
-      hosted_field_send_input("expirationDate", "2")
-
-      expect(page).to have_button('Pay', disabled: true)
-
-      # Put in valid state again
-      hosted_field_send_input("expirationDate", :backspace)
-      hosted_field_send_input("expirationDate", "9")
-
-      expect(page).to have_button('Pay', disabled: false)
-    end
-
-    it "enable submit button on PayPal authorization" do
-      visit "http://#{HOSTNAME}:#{PORT}"
-
-      click_option("paypal")
-
-      expect(page).to have_button('Pay', disabled: true)
-
-      open_popup_and_complete_login
-
-      expect(page).to have_button('Pay', disabled: false)
-
-      find('.braintree-toggle').click
-
-      expect(page).to have_button('Pay', disabled: false)
-
-      click_option("paypal")
-
-      expect(page).to have_button('Pay', disabled: true)
-
-      find('.braintree-toggle').click
-
-      expect(page).to have_button('Pay', disabled: false)
     end
   end
 end

--- a/spec/helpers/drop_in_helper.rb
+++ b/spec/helpers/drop_in_helper.rb
@@ -9,7 +9,10 @@ module DropIn
   end
 
   def submit_pay
-    sleep 1
-    find("input[type='submit']").click
+    button = find("input[type='submit']")
+
+    sleep 2
+
+    button.click
   end
 end

--- a/spec/helpers/drop_in_helper.rb
+++ b/spec/helpers/drop_in_helper.rb
@@ -9,6 +9,7 @@ module DropIn
   end
 
   def submit_pay
+    sleep 1
     find("input[type='submit']").click
   end
 end

--- a/spec/helpers/paypal_helper.rb
+++ b/spec/helpers/paypal_helper.rb
@@ -15,6 +15,8 @@ module PayPal
 
       block.call if block
 
+      sleep 1
+
       click_button("confirmButtonTop", wait: 30)
     end
 

--- a/spec/helpers/paypal_helper.rb
+++ b/spec/helpers/paypal_helper.rb
@@ -15,8 +15,6 @@ module PayPal
 
       block.call if block
 
-      sleep 1
-
       click_button("confirmButtonTop", wait: 30)
     end
 
@@ -32,6 +30,8 @@ module PayPal
 		within_frame login_iframe do
 			fill_in("email", :with => ENV["PAYPAL_USERNAME"])
 			fill_in("password", :with => ENV["PAYPAL_PASSWORD"])
+
+      sleep 1
 
 			click_button("btnLogin")
 		end

--- a/spec/helpers/paypal_helper.rb
+++ b/spec/helpers/paypal_helper.rb
@@ -23,19 +23,19 @@ module PayPal
   end
 
   def login_to_paypal
-		expect(page).to have_text("Pay with PayPal", wait: 30)
+    expect(page).to have_text("Pay with PayPal", wait: 30)
 
-		login_iframe = find("#injectedUnifiedLogin iframe")
+    login_iframe = find("#injectedUnifiedLogin iframe")
 
-		within_frame login_iframe do
-			fill_in("email", :with => ENV["PAYPAL_USERNAME"])
-			fill_in("password", :with => ENV["PAYPAL_PASSWORD"])
+    within_frame login_iframe do
+      fill_in("email", :with => ENV["PAYPAL_USERNAME"])
+      fill_in("password", :with => ENV["PAYPAL_PASSWORD"])
 
       sleep 1
 
-			click_button("btnLogin")
-		end
+      click_button("btnLogin")
+    end
 
-		expect(page).to have_selector("#confirmButtonTop")
+    expect(page).to have_selector("#confirmButtonTop")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,6 @@ RSpec.configure do |config|
   config.around(:each) do |c|
     c.run_with_retry(retry: 2)
   end
-  config.fail_fast = 1
 
   config.around(:each, :paypal) do |c|
     c.run_with_retry(retry: 4, retry_wait: 4)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
   config.around(:each) do |c|
     c.run_with_retry(retry: 2)
   end
+  config.fail_fast = 1
 
   config.around(:each, :paypal) do |c|
     c.run_with_retry(retry: 4, retry_wait: 4)

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -51,7 +51,6 @@
 
 </head>
 <body>
-
 <h1>Braintree Drop-in demo</h1>
 
 <p>You can create a <a href="https://developer.paypal.com/docs/classic/lifecycle/sb_about-accounts/#creating-sandbox-test-accounts" target="_blank" rel="nofollow">PayPal Sandbox account</a> to test the PayPal flow. You will need to contact <a href="mailto:support@braintreepayments.com">Braintree Support</a> to link your PayPal Sandbox account with the Braintree Gateway.</p>


### PR DESCRIPTION
### Summary

Puts tokenization tests at the top so if they fail, we can cancel the build out early and deal with it.

Adds an extra sleep before pressing the confirm button, because it seems like a major cause of our build failures is IE9 failing to complete the flow. Once the button is clicked, the popup closes, but never messages back to the page that the flow is complete.

### Checklist

- [ ] ~~Added a changelog entry~~
- [ ] ~~Ran unit tests~~
