### PR TITLE
Fix error thrown by Hosted Fields when CVV is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Fix localization for placeholders
+- Fix error thrown when CVV was not enabled
 
 1.0.0-beta.7
 ----------

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -75,6 +75,7 @@ CardView.prototype._initialize = function () {
   cardIcons.innerHTML = cardIconHTML;
   this._hideUnsupportedCardIcons();
 
+  this.hasCVV = hasCVV;
   this.cardNumberIcon = this.getElementById('card-number-icon');
   this.cardNumberIconSvg = this.getElementById('card-number-icon-svg');
   this.cvvIcon = this.getElementById('cvv-icon');
@@ -299,13 +300,16 @@ CardView.prototype._onCardTypeChangeEvent = function (event) {
   }
 
   this.cardNumberIconSvg.setAttribute('xlink:href', cardNumberHrefLink);
-  this.cvvIconSvg.setAttribute('xlink:href', cvvHrefLink);
-  this.cvvLabelDescriptor.textContent = cvvDescriptor;
-  this.hostedFieldsInstance.setAttribute({
-    field: 'cvv',
-    attribute: 'placeholder',
-    value: cvvPlaceholder
-  });
+
+  if (this.hasCVV) {
+    this.cvvIconSvg.setAttribute('xlink:href', cvvHrefLink);
+    this.cvvLabelDescriptor.textContent = cvvDescriptor;
+    this.hostedFieldsInstance.setAttribute({
+      field: 'cvv',
+      attribute: 'placeholder',
+      value: cvvPlaceholder
+    });
+  }
 };
 
 CardView.prototype._onFocusEvent = function (event) {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -842,6 +842,33 @@ describe('CardView', function () {
 
         expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
       });
+
+      it('does not update the cvv field placeholder when cvv field does not exist', function () {
+        var fakeEvent = {
+          cards: [{type: 'american-express'}, {type: 'visa'}],
+          emittedBy: 'number'
+        };
+        var hostedFieldsInstance = {
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setAttribute: this.sandbox.spy()
+        };
+
+        this.context.client.getConfiguration = function () {
+          return {
+            gatewayConfiguration: {
+              challenges: [],
+              creditCards: {
+                supportedCardTypes: []
+              }
+            }
+          };
+        };
+
+        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        CardView.prototype._initialize.call(this.context);
+
+        expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
+      });
     });
 
     describe('onValidityChangeEvent', function () {


### PR DESCRIPTION
### Summary
An error was thrown in the console when Hosted Fields tried to update the cvv placeholder when cvv was not enabled. This checks to see if a cvv field exists before trying to update the placeholder.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
