### PR TITLE
Only show field errors when focusing on another Hosted Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Show empty field errors only when another field is focused
+
 1.0.0
 -----
 - Fix localization for placeholders

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -265,12 +265,14 @@ CardView.prototype._generateFieldSelector = function (field) {
 CardView.prototype._onBlurEvent = function (event) {
   var field = event.fields[event.emittedBy];
   var fieldGroup = this.getElementById(camelCaseToSnakeCase(event.emittedBy) + '-field-group');
+  var activeId = document.activeElement && document.activeElement.id;
+  var isHostedFieldsElement = document.activeElement instanceof HTMLIFrameElement && activeId.indexOf('braintree-hosted-field') !== -1;
 
   classlist.remove(fieldGroup, 'braintree-form__field-group--is-focused');
 
-  if (field.isEmpty) {
+  if (isHostedFieldsElement && field.isEmpty) {
     this.showFieldError(event.emittedBy, this.strings['fieldEmptyFor' + capitalize(event.emittedBy)]);
-  } else if (!field.isValid) {
+  } else if (!field.isEmpty && !field.isValid) {
     this.showFieldError(event.emittedBy, this.strings['fieldInvalidFor' + capitalize(event.emittedBy)]);
   } else if (event.emittedBy === 'number' && !this._isCardTypeSupported(event.cards[0].type)) {
     this.showFieldError('number', this.strings.unsupportedCardTypeError);


### PR DESCRIPTION
### Summary

When switching from an empty card form to another payment type we show an error because we are bluring the card number input.

Fixing this by only showing an empty field error when the new active element is a Hosted Fields element. Otherwise we don't show an error.

### Checklist

- [x] Added a changelog entry
- [X] Ran unit tests
