### PR TITLE
Fix card icon overflow in small browser windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Show empty field errors only when another field is focused
+- Fix card icon overflow in small browser windows
 
 1.0.0
 -----

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -432,7 +432,6 @@ $loader-scale-duration: 300ms;
   }
 
   .braintree-sheet__icons {
-    display: flex;
     padding-bottom: 10px;
   }
 }


### PR DESCRIPTION
### Summary
Manually ran through Chrome, iOS simulator, and IE 9.

Before:
![screen shot 2017-05-08 at 10 21 40 am](https://cloud.githubusercontent.com/assets/7514489/25811284/5e431d42-33d8-11e7-8321-b222ccb3747a.png)
After:
![screen shot 2017-05-08 at 10 21 50 am](https://cloud.githubusercontent.com/assets/7514489/25811286/6084814a-33d8-11e7-89c3-417157e9cb38.png)

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
