### PR TITLE
Add timeout for async dependencies in PayPal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Add timeout for async dependencies in PayPal
+
 1.0.1
 -----
 - Fix card icon overflow in small browser windows

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -21,7 +21,10 @@ BasePayPalView.prototype._initialize = function (isCredit) {
 
   this.model.asyncDependencyStarting();
   asyncDependencyTimeoutHandler = setTimeout(function () {
-    self.model.asyncDependencyFailed({view: self.ID});
+    self.model.asyncDependencyFailed({
+      view: self.ID,
+      error: {message: 'There was an error connecting to PayPal.'}
+    });
   }, ASYNC_DEPENDENCY_TIMEOUT);
 
   btPaypal.create({client: this.client}, function (err, paypalInstance) {

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var BaseView = require('../base-view');
 var assign = require('../../lib/assign').assign;
+var BaseView = require('../base-view');
 var btPaypal = require('braintree-web/paypal-checkout');
+var DropinError = require('../../lib/dropin-error');
 
 var ASYNC_DEPENDENCY_TIMEOUT = 30000;
 
@@ -23,7 +24,7 @@ BasePayPalView.prototype._initialize = function (isCredit) {
   asyncDependencyTimeoutHandler = setTimeout(function () {
     self.model.asyncDependencyFailed({
       view: self.ID,
-      error: {message: 'There was an error connecting to PayPal.'}
+      error: new DropinError('There was an error connecting to PayPal.')
     });
   }, ASYNC_DEPENDENCY_TIMEOUT);
 

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -3,6 +3,7 @@
 
 var BaseView = require('../../../../src/views/base-view');
 var DropinModel = require('../../../../src/dropin-model');
+var DropinError = require('../../../../src/lib/dropin-error');
 var fake = require('../../../helpers/fake');
 var fs = require('fs');
 var PayPalCheckout = require('braintree-web/paypal-checkout');
@@ -443,6 +444,8 @@ describe('BasePayPalView', function () {
       });
 
       it('times out if the async dependency is never ready', function () {
+        var paypalError = new DropinError('There was an error connecting to PayPal.');
+
         this.sandbox.useFakeTimers();
 
         this.sandbox.stub(DropinModel.prototype, 'asyncDependencyFailed');
@@ -452,7 +455,10 @@ describe('BasePayPalView', function () {
 
         this.sandbox.clock.tick(30001);
 
-        expect(DropinModel.prototype.asyncDependencyFailed).to.be.calledWith({view: this.view.ID});
+        expect(DropinModel.prototype.asyncDependencyFailed).to.be.calledWith(this.sandbox.match({
+          view: this.view.ID,
+          error: paypalError
+        }));
       });
 
       it('does not timeout if async dependency sets up', function () {


### PR DESCRIPTION
### Summary

This adds a timeout for loading PayPal dependencies. When PayPal sandbox was down, Drop-in got stuck at the spinner. Now the payment options view loads with PayPal options greyed out with an error message. This message isn't currently translated, but as it was added for sandbox issues I'm fine with adding it as is for now and adding the translations as we get them.

<img width="537" alt="screen shot 2017-05-11 at 11 26 47 am" src="https://cloud.githubusercontent.com/assets/7514489/25960606/0332d3cc-363d-11e7-9989-aa996b2b5ed5.png">

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests

