### PR TITLE
Typo on Dutch translation file

### DIFF
--- a/src/translations/nl_NL.js
+++ b/src/translations/nl_NL.js
@@ -28,7 +28,7 @@ module.exports = {
   "cvvLabel": "CVV",
   "cvvThreeDigitLabelSubheading": "(3 cijfers)",
   "cvvFourDigitLabelSubheading": "(4 cijfers)",
-  "expirationDateLabel": "VervaldatumB",
+  "expirationDateLabel": "Vervaldatum",
   "expirationDateLabelSubheading": "(MM/JJ)",
   "expirationDatePlaceholder": "MM/JJ",
   "postalCodeLabel": "Postcode",


### PR DESCRIPTION
### Summary
This will fix a Typo on the Dutch translation file.

### Checklist
- [ ] Added a changelog entry
- [ ] Ran unit tests
