### PR TITLE
Readme.md: Reference the release branch for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you have any feedback or questions, create an [issue](https://github.com/brai
 
 - Updated UI to easily accommodate multiple payment methods
 - Not in an iframe; feel free to style Drop-in to blend in with your website
-- Now available in [23 languages](#localization)
+- Now available in [23 languages](https://github.com/braintree/braintree-web-drop-in/tree/release#localization)
 - Open source and open development
 
 ## Getting started


### PR DESCRIPTION
### Summary

The commit 9657cc8cbf95233791d60de7ecf8b66d5e326795 updated the readme to point to the release branch of the docs until the JSDocs are available.  This fixes the reference to the localization link until that point also.  All other links look like they are functioning.  This would also need to be updated when the JSDocs are ready.

### Checklist

- [ ] Added a changelog entry
- [ ] Ran unit tests

I did not do either of those because this is a documentation change.  It would appear that there are not unit tests for the documentation.  It would also be strange to document this in the changelog as other larger documentation changes have not been.
