### PR TITLE
Add github pages release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint src test",
     "pretest": "npm run lint",
     "test": "karma start test/config/karma.js --single-run",
-    "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec"
+    "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
+    "deploy:gh-pages": "./scripts/deploy-gh-pages"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "gulp build",
     "development": "gulp development",
-    "gh-pages": "gulp build:gh-pages",
+    "build:gh-pages": "gulp build:gh-pages",
     "lint": "eslint src test",
     "pretest": "npm run lint",
     "test": "karma start test/config/karma.js --single-run",

--- a/scripts/deploy-gh-pages
+++ b/scripts/deploy-gh-pages
@@ -18,16 +18,9 @@ commit_and_push() {
   set -e
 }
 
-#TEMP_DIRECTORY=/tmp/braintree-web-drop-in-temp
 BT_DROPIN_DIR=~/bt/braintree-web-drop-in
 
-#if [ -d "$TEMP_DIRECTORY" ]; then
-#  rm -rf "$TEMP_DIRECTORY"
-#fi
-
-echo -e "Building jsdoc...\n"
-cd "$BT_DROPIN_DIR" && npm run build:gh-pages
-#cp -r $BT_DROPIN_DIR/dist/gh-pages $TEMP_DIRECTORY
+cd "$BT_DROPIN_DIR"
 
 echo -e "Building dropin...\n"
 npm run build
@@ -45,14 +38,7 @@ echo -e "Copying new dropin.css/js...\n"
 cp dist/web/dropin/dev/css/dropin.css web/dropin/dev/css
 cp dist/web/dropin/dev/js/dropin.js web/dropin/dev/js
 
-#cp -r $TEMP_DIRECTORY/docs/$npm_package_version .
-#cp -r $TEMP_DIRECTORY/docs/current .
-#cp -r $TEMP_DIRECTORY/index.html .
-
 commit_and_push
-
-#echo -e "Removing cloned braintree-web"
-#rm -rf "$TEMP_DIRECTORY"
 
 echo -e "Checking out previous branch...\n"
 git checkout -

--- a/scripts/deploy-gh-pages
+++ b/scripts/deploy-gh-pages
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -u
+set -e
+
+run_ressh() {
+  source "$HOME/.aliases"
+  ressh
+}
+
+commit_and_push() {
+  set +e
+  git clean -fd
+  git add .
+  git commit -m "Add version $npm_package_version"
+  run_ressh
+  git push origin gh-pages
+  set -e
+}
+
+TEMP_DIRECTORY=/tmp/braintree-web-drop-in-temp
+BT_DROPIN_DIR=~/bt/braintree-web-drop-in
+
+if [ -d "$TEMP_DIRECTORY" ]; then
+  rm -rf "$TEMP_DIRECTORY"
+fi
+
+echo -e "Building jsdoc...\n"
+cd "$BT_DROPIN_DIR" && npm run build:gh-pages
+cp -r $BT_DROPIN_DIR/dist/gh-pages $TEMP_DIRECTORY
+
+git co gh-pages
+git config user.name Braintree
+git config user.email code@getbraintree.com
+
+echo -e "Adding new jsdocs version...\n"
+cp -r $TEMP_DIRECTORY/docs/$npm_package_version .
+cp -r $TEMP_DIRECTORY/docs/current .
+cp -r $TEMP_DIRECTORY/index.html .
+#commit_and_push
+#
+#echo -e "Removing cloned braintree-web"
+#rm -rf "$TEMP_DIRECTORY"
+#
+#echo "Finished, exiting."

--- a/scripts/deploy-gh-pages
+++ b/scripts/deploy-gh-pages
@@ -10,36 +10,51 @@ run_ressh() {
 
 commit_and_push() {
   set +e
-  git clean -fd
-  git add .
+  g add .
+  echo -e "Committing and pushing new gh-pages...\n"
   git commit -m "Add version $npm_package_version"
   run_ressh
   git push origin gh-pages
   set -e
 }
 
-TEMP_DIRECTORY=/tmp/braintree-web-drop-in-temp
+#TEMP_DIRECTORY=/tmp/braintree-web-drop-in-temp
 BT_DROPIN_DIR=~/bt/braintree-web-drop-in
 
-if [ -d "$TEMP_DIRECTORY" ]; then
-  rm -rf "$TEMP_DIRECTORY"
-fi
+#if [ -d "$TEMP_DIRECTORY" ]; then
+#  rm -rf "$TEMP_DIRECTORY"
+#fi
 
 echo -e "Building jsdoc...\n"
 cd "$BT_DROPIN_DIR" && npm run build:gh-pages
-cp -r $BT_DROPIN_DIR/dist/gh-pages $TEMP_DIRECTORY
+#cp -r $BT_DROPIN_DIR/dist/gh-pages $TEMP_DIRECTORY
 
-git co gh-pages
+echo -e "Building dropin...\n"
+npm run build
+
+git checkout gh-pages
+git pull
+
 git config user.name Braintree
 git config user.email code@getbraintree.com
 
-echo -e "Adding new jsdocs version...\n"
-cp -r $TEMP_DIRECTORY/docs/$npm_package_version .
-cp -r $TEMP_DIRECTORY/docs/current .
-cp -r $TEMP_DIRECTORY/index.html .
-#commit_and_push
-#
+echo -e "Copying new jsdocs gh-pages...\n"
+cp -r dist/gh-pages/* .
+
+echo -e "Copying new dropin.css/js...\n"
+cp dist/web/dropin/dev/css/dropin.css web/dropin/dev/css
+cp dist/web/dropin/dev/js/dropin.js web/dropin/dev/js
+
+#cp -r $TEMP_DIRECTORY/docs/$npm_package_version .
+#cp -r $TEMP_DIRECTORY/docs/current .
+#cp -r $TEMP_DIRECTORY/index.html .
+
+commit_and_push
+
 #echo -e "Removing cloned braintree-web"
 #rm -rf "$TEMP_DIRECTORY"
-#
-#echo "Finished, exiting."
+
+echo -e "Checking out previous branch...\n"
+git checkout -
+
+echo "Finished, exiting."

--- a/scripts/deploy-gh-pages
+++ b/scripts/deploy-gh-pages
@@ -10,7 +10,7 @@ run_ressh() {
 
 commit_and_push() {
   set +e
-  g add .
+  git add .
   echo -e "Committing and pushing new gh-pages...\n"
   git commit -m "Add version $npm_package_version"
   run_ressh

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 
-<link rel="stylesheet" type="text/css" href="/web/dropin/dev/css/dropin.css" id="braintree-dropin-stylesheet">
+<link rel="stylesheet" type="text/css" href="web/dropin/dev/css/dropin.css" id="braintree-dropin-stylesheet">
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -68,7 +68,7 @@
 <pre id="results"></pre>
 
 <script src="assign-polyfill.js"></script>
-<script src="/web/dropin/dev/js/dropin.js"></script>
+<script src="web/dropin/dev/js/dropin.js"></script>
 
 <script>
   var defaultCreateObject = {


### PR DESCRIPTION
### Summary
Build and deploy github pages for Drop-in.

We build Drop-in assets and copy them to `web/dropin/dev/css/dropin.css` and `web/dropin/dev/js/dropin.js` for use on the demo page. This is potentially better than using the CDN because with the local path, the demo page always uses the documented version of Drop-in; the versions are in-sync. Also, rewriting the script and style tags at build time could be brittle.