### PR TITLE
Fix jsdoc generation on mac

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -168,8 +168,9 @@ function jsdoc(options, done) {
   var args = ['jsdoc', 'src'];
   var command = 'bash';
   var commandOption = '-c';
+  var platform = process.platform;
 
-  if (process.platform.indexOf('win')>=0) {
+  if (platform !== 'darwin' && platform.indexOf('win') >= 0) {
     command = 'cmd';
     commandOption = '/c';
   }


### PR DESCRIPTION
### Summary

We were checking for `win` in the platform to determine if it is windows. Mac's platform is `darwin` which was being caught by it.

### Checklist

- [ ] ~~Added a changelog entry~~
- [ ] ~~Ran unit tests~~
