### PR TITLE
Catch errors from paypal.Button.render

### DIFF
--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -119,6 +119,9 @@ DropinModel.prototype.asyncDependencyReady = function () {
 };
 
 DropinModel.prototype.asyncDependencyFailed = function (options) {
+  if (this.failedDependencies.hasOwnProperty(options.view)) {
+    return;
+  }
   this.failedDependencies[options.view] = options.error;
   this.dependenciesInitializing--;
   this._checkAsyncDependencyFinished();

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -79,7 +79,7 @@ BasePayPalView.prototype._initialize = function (isCredit) {
       self.model.asyncDependencyReady();
       setupComplete = true;
       clearTimeout(asyncDependencyTimeoutHandler);
-    });
+    }).catch(reportError);
   });
 
   function reportError(err) {

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -356,6 +356,23 @@ describe('DropinModel', function () {
       expect(this.model.failedDependencies.id).to.equal(err);
     });
 
+    it('ignores error if failure was already reported', function () {
+      var err = new Error('a bad error');
+      var ignoredError = new Error('a different error');
+
+      this.model.asyncDependencyFailed({
+        view: 'id',
+        error: err
+      });
+      this.model.asyncDependencyFailed({
+        view: 'id',
+        error: ignoredError
+      });
+
+      expect(this.model.failedDependencies.id).to.not.equal(ignoredError);
+      expect(this.model.failedDependencies.id).to.equal(err);
+    });
+
     it('emits asyncDependenciesReady event when there are no dependencies initializing', function (done) {
       var model = new DropinModel(this.modelOptions);
 

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -300,6 +300,24 @@ describe('BasePayPalView', function () {
       });
     });
 
+    it('reports errors from paypal.Button.render', function (done) {
+      var error = new Error('setup error');
+
+      this.sandbox.stub(this.model, 'asyncDependencyFailed');
+      this.paypal.Button.render.rejects(error);
+
+      this.view._initialize();
+
+      waitForInitialize(function () {
+        expect(this.model.asyncDependencyFailed).to.be.calledOnce;
+        expect(this.model.asyncDependencyFailed).to.be.calledWithMatch({
+          view: this.view.ID,
+          error: new DropinError(error)
+        });
+        done();
+      }.bind(this));
+    });
+
     it('calls addPaymentMethod when paypal is tokenized', function (done) {
       var paypalInstance = this.paypalInstance;
       var model = this.model;
@@ -498,7 +516,13 @@ describe('BasePayPalView', function () {
       var model = this.model;
 
       this.sandbox.stub(model, 'asyncDependencyFailed');
-      this.paypal.Button.render.rejects();
+      // we need a fake promise so that it neither resolves
+      // or rejects
+      this.paypal.Button.render.returns({
+        then: this.sandbox.stub().returns({
+          'catch': this.sandbox.stub()
+        })
+      });
       this.view._initialize();
 
       waitForInitialize(function () {
@@ -663,7 +687,9 @@ describe('BasePayPalView', function () {
         // promises can't resolve while using fake timers
         // so we make a fake promise
         this.paypal.Button.render.returns({
-          then: this.sandbox.stub().yields()
+          then: this.sandbox.stub().yields().returns({
+            'catch': this.sandbox.stub()
+          })
         });
 
         this.view._initialize();


### PR DESCRIPTION
### Summary

Allows the PayPal view to fail early if paypal.Button.render has an error that isn't bubbled up to it's `onError` handler. 

You can reproduce this by providing a `locale` that is invalid for checkout.js.

### Checklist

- [ ] ~~Added a changelog entry~~ (already included, we just didn't add this case earlier)
- [x] Ran unit tests
