### PR TITLE
Allow card overrides with Hosted Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ UNRELEASED
 - Fix typo in russian translation
 - Update browser detection library to 1.4.0
 - Fix width errors where Drop-in was not aligned with other elements on merchant page
+- Allow customizing hosted fields configuration
 
 1.1.0
 ----------

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -232,4 +232,43 @@ describe "Drop-in" do
       expect(find("#error")).to have_content("paymentOptionPriority: Invalid payment option specified.")
     end
   end
+
+  describe "Hosted Fields overrides" do
+    it "can remove a field from the card form" do
+      options = '{"overrides":{"fields":{"cvv":null}}}'
+      visit URI.encode("http://#{HOSTNAME}:#{PORT}?card=#{options}")
+
+      click_option("card")
+
+      expect(page).to have_content("Card Number")
+      expect(page).to have_content("Expiration Date")
+      expect(page).to_not have_content("CVV")
+    end
+
+    it "can override field configurations" do
+      options = '{"overrides":{"fields":{"cvv":{"placeholder":"my placeholder"}}}}'
+      visit URI.encode("http://#{HOSTNAME}:#{PORT}?card=#{options}")
+
+      click_option("card")
+
+      iframe = find("iframe[id='braintree-hosted-field-cvv']")
+
+      within_frame(iframe) do
+        expect(find("input").native.attribute("placeholder")).to eq("my placeholder")
+      end
+    end
+
+    it "can override style configurations" do
+      options = '{"overrides":{"styles":{"input":{"font-size":"20px"}}}}'
+      visit URI.encode("http://#{HOSTNAME}:#{PORT}?card=#{options}")
+
+      click_option("card")
+
+      iframe = find("iframe[id='braintree-hosted-field-cvv']")
+
+      within_frame(iframe) do
+        expect(find("input").native.css_value("font-size")).to eq("20px")
+      end
+    end
+  end
 end

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,9 @@ var VERSION = process.env.npm_package_version;
  * `zh_TW`.
  * @param {array} [options.paymentOptionPriority] Use this option to indicate the order in which enabled payment options should appear when multiple payment options are enabled. By default, payment options will appear in this order: `['card', 'paypal', 'paypalCredit']`. Payment options omitted from this array will not be offered to the customer.
  *
+ * @param {object} [options.card] The configuration options for cards. If this option is omitted, cards will still appear as a payment option. To remove cards as a payment option, use `paymentOptionPriority`. Internally, Drop-in uses [Hosted Fields](http://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html) to render the card form. The `overrides.fields` and `overrides.styles` configuration can be customized.
+ * @param {object} [options.card.overrides.fields] The Hosted Fields [`fields` options](http://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html#~fieldOptions). Only `number`, `cvv`, `expirationDate` and `postalCode` can be configured. Each is a [Hosted Fields `field` object](http://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html#~field). `selector` cannot be modified.
+ * @param {object} [options.card.overrides.styles] The Hosted Fields [`styles` options](http://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html#~styleOptions).
  * @param {object} [options.paypal] The configuration options for PayPal. To include a PayPal option in your Drop-in integration, include the `paypal` parameter and [enable PayPal in the Braintree Control Panel](https://developers.braintreepayments.com/guides/paypal/testing-go-live/#go-live). To test in Sandbox, you will need to [link a PayPal sandbox test account to your Braintree sandbox account](https://developers.braintreepayments.com/guides/paypal/testing-go-live/#linked-paypal-testing).
  *
  * Some of the PayPal configuration options are listed here, but for a full list see the [PayPal Checkout client reference options](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/PayPalCheckout.html#createPayment).
@@ -171,6 +174,34 @@ var VERSION = process.env.npm_package_version;
  *     </script>
  *   </body>
  * </html>
+ *
+ * @example
+ * <caption>Customizing Drop-in with card form overrides</caption>
+ * braintree.dropin.create({
+ *   authorization: 'CLIENT_AUTHORIZATION',
+ *   container: '#dropin-container',
+ *   card: {
+ *     overrides: {
+ *       fields: {
+ *         number: {
+ *           placeholder: '1111 1111 1111 1111' // Update the number field placeholder
+ *         },
+ *         postalCode: {
+ *           minlength: 5 // Set the minimum length of the postal code field
+ *         },
+ *         cvv: null // Remove the CVV field from your form
+ *       },
+ *       styles: {
+ *         input: {
+ *           'font-size': '18px' // Change the font size for all inputs
+ *         },
+ *         ':focus': {
+ *           color: 'red' // Change the focus color to red for all inputs
+ *         }
+ *       }
+ *     }
+ *   }
+ * }, callback);
  */
 
 function create(options, callback) {

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -128,6 +128,10 @@ CardView.prototype._generateHostedFieldsOptions = function () {
   }
 
   if (overrides.fields) {
+    if (overrides.fields.cvv && overrides.fields.cvv.placeholder) {
+      this._hasCustomCVVPlaceholder = true;
+    }
+
     Object.keys(overrides.fields).forEach(function (field) {
       if ((field === 'cvv' || field === 'postalCode') && overrides.fields[field] === null) {
         delete options.fields[field];
@@ -350,11 +354,14 @@ CardView.prototype._onCardTypeChangeEvent = function (event) {
   if (this.hasCVV) {
     this.cvvIconSvg.setAttribute('xlink:href', cvvHrefLink);
     this.cvvLabelDescriptor.textContent = cvvDescriptor;
-    this.hostedFieldsInstance.setAttribute({
-      field: 'cvv',
-      attribute: 'placeholder',
-      value: cvvPlaceholder
-    });
+
+    if (!this._hasCustomCVVPlaceholder) {
+      this.hostedFieldsInstance.setAttribute({
+        field: 'cvv',
+        attribute: 'placeholder',
+        value: cvvPlaceholder
+      });
+    }
   }
 };
 

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -76,7 +76,7 @@ CardView.prototype._initialize = function () {
 };
 
 CardView.prototype._generateHostedFieldsOptions = function () {
-  var hfOverrides = this.model.merchantConfiguration.card && this.model.merchantConfiguration.card.hostedFieldsOverrides;
+  var overrides = this.model.merchantConfiguration.card && this.model.merchantConfiguration.card.overrides;
   var options = {
     client: this.client,
     fields: {
@@ -123,13 +123,13 @@ CardView.prototype._generateHostedFieldsOptions = function () {
     }
   };
 
-  if (!hfOverrides) {
+  if (!overrides) {
     return options;
   }
 
-  if (hfOverrides.fields) {
-    Object.keys(hfOverrides.fields).forEach(function (field) {
-      if ((field === 'cvv' || field === 'postalCode') && hfOverrides.fields[field] === null) {
+  if (overrides.fields) {
+    Object.keys(overrides.fields).forEach(function (field) {
+      if ((field === 'cvv' || field === 'postalCode') && overrides.fields[field] === null) {
         delete options.fields[field];
         return;
       }
@@ -138,20 +138,20 @@ CardView.prototype._generateHostedFieldsOptions = function () {
         return;
       }
 
-      assign(options.fields[field], hfOverrides.fields[field], {
+      assign(options.fields[field], overrides.fields[field], {
         selector: options.fields[field].selector
       });
     });
   }
 
-  if (hfOverrides.styles) {
-    Object.keys(hfOverrides.styles).forEach(function (style) {
-      if (hfOverrides.styles[style] === null) {
+  if (overrides.styles) {
+    Object.keys(overrides.styles).forEach(function (style) {
+      if (overrides.styles[style] === null) {
         delete options.styles[style];
         return;
       }
 
-      assign(options.styles[style], hfOverrides.styles[style]);
+      assign(options.styles[style], overrides.styles[style]);
     });
   }
 

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -12,7 +12,7 @@ var transitionHelper = require('../../../../src/lib/transition-helper');
 
 var mainHTML = fs.readFileSync(__dirname + '/../../../../src/html/main.html', 'utf8');
 
-describe.only('CardView', function () {
+describe('CardView', function () {
   beforeEach(function () {
     this.div = document.createElement('div');
 

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -1167,6 +1167,32 @@ describe('CardView', function () {
 
         expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
       });
+
+      it('does not update the cvv field placeholder when using a custom CVV placeholder', function () {
+        var fakeEvent = {
+          cards: [{type: 'american-express'}, {type: 'visa'}],
+          emittedBy: 'number'
+        };
+        var hostedFieldsInstance = {
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setAttribute: this.sandbox.spy()
+        };
+
+        this.context.model.merchantConfiguration.card = {
+          overrides: {
+            fields: {
+              cvv: {
+                placeholder: 'cool custom placeholder'
+              }
+            }
+          }
+        };
+
+        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        CardView.prototype._initialize.call(this.context);
+
+        expect(hostedFieldsInstance.setAttribute).not.to.have.been.called;
+      });
     });
 
     describe('onValidityChangeEvent', function () {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -91,7 +91,7 @@ describe('CardView', function () {
       };
 
       this.model.merchantConfiguration.card = {
-        hostedFieldsOverrides: {
+        overrides: {
           fields: {
             cvv: null
           }
@@ -157,7 +157,7 @@ describe('CardView', function () {
       };
 
       this.model.merchantConfiguration.card = {
-        hostedFieldsOverrides: {
+        overrides: {
           fields: {
             postalCode: null
           }
@@ -418,7 +418,7 @@ describe('CardView', function () {
         };
       };
       this.model.merchantConfiguration.card = {
-        hostedFieldsOverrides: {
+        overrides: {
           fields: {
             number: {
               placeholder: 'placeholder'
@@ -448,7 +448,7 @@ describe('CardView', function () {
       var hostedFieldsConfiguredFields;
 
       this.model.merchantConfiguration.card = {
-        hostedFieldsOverrides: {
+        overrides: {
           fields: {
             postalCode: {
               selector: '#postal-code'
@@ -486,7 +486,7 @@ describe('CardView', function () {
       var hostedFieldsConfiguredFields;
 
       this.model.merchantConfiguration.card = {
-        hostedFieldsOverrides: {
+        overrides: {
           fields: {
             number: {
               selector: '#some-selector'
@@ -512,7 +512,7 @@ describe('CardView', function () {
       var hostedFieldsConfiguredStyles;
 
       this.model.merchantConfiguration.card = {
-        hostedFieldsOverrides: {
+        overrides: {
           styles: {
             input: {
               background: 'blue',

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -12,7 +12,7 @@ var transitionHelper = require('../../../../src/lib/transition-helper');
 
 var mainHTML = fs.readFileSync(__dirname + '/../../../../src/html/main.html', 'utf8');
 
-describe('CardView', function () {
+describe.only('CardView', function () {
   beforeEach(function () {
     this.div = document.createElement('div');
 
@@ -78,6 +78,37 @@ describe('CardView', function () {
       expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).to.exist;
     });
 
+    it('does not have cvv if supplied in challenges, but hosted fields overrides sets cvv to null', function () {
+      this.client.getConfiguration = function () {
+        return {
+          gatewayConfiguration: {
+            challenges: ['cvv'],
+            creditCards: {
+              supportedCardTypes: []
+            }
+          }
+        };
+      };
+
+      this.model.merchantConfiguration.card = {
+        hostedFieldsOverrides: {
+          fields: {
+            cvv: null
+          }
+        }
+      };
+
+      new CardView({ // eslint-disable-line no-new
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
+    });
+
     it('does not have cvv if not supplied in challenges', function () {
       new CardView({ // eslint-disable-line no-new
         element: this.element,
@@ -111,6 +142,37 @@ describe('CardView', function () {
       });
 
       expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).to.exist;
+    });
+
+    it('does not have postal code if supplied in challenges, but hosted fields overrides sets postal code to null', function () {
+      this.client.getConfiguration = function () {
+        return {
+          gatewayConfiguration: {
+            challenges: ['postal_code'],
+            creditCards: {
+              supportedCardTypes: []
+            }
+          }
+        };
+      };
+
+      this.model.merchantConfiguration.card = {
+        hostedFieldsOverrides: {
+          fields: {
+            postalCode: null
+          }
+        }
+      };
+
+      new CardView({ // eslint-disable-line no-new
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
     });
 
     it('does not have postal code if not supplied in challenges', function () {
@@ -341,6 +403,144 @@ describe('CardView', function () {
       expect(hostedFieldsConfiguredFields.cvv.placeholder).to.equal('•••');
       expect(hostedFieldsConfiguredFields.postalCode.placeholder).to.not.exist;
     });
+
+    it('allows overriding field options for hosted fields', function () {
+      var hostedFieldsConfiguredFields;
+
+      this.client.getConfiguration = function () {
+        return {
+          gatewayConfiguration: {
+            challenges: ['cvv', 'postal_code'],
+            creditCards: {
+              supportedCardTypes: []
+            }
+          }
+        };
+      };
+      this.model.merchantConfiguration.card = {
+        hostedFieldsOverrides: {
+          fields: {
+            number: {
+              placeholder: 'placeholder'
+            },
+            cvv: {
+              maxlength: 2
+            }
+          }
+        }
+      };
+
+      new CardView({ // eslint-disable-line no-new
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+
+      expect(hostedFieldsConfiguredFields.number.placeholder).to.equal('placeholder');
+      expect(hostedFieldsConfiguredFields.cvv.maxlength).to.equal(2);
+    });
+
+    it('does not add hosted fields elements for fields that are not present', function () {
+      var hostedFieldsConfiguredFields;
+
+      this.model.merchantConfiguration.card = {
+        hostedFieldsOverrides: {
+          fields: {
+            postalCode: {
+              selector: '#postal-code'
+            },
+            cvv: {
+              selector: '#cvv'
+            },
+            expirationMonth: {
+              selector: '#month'
+            },
+            expirationYear: {
+              selector: '#year'
+            }
+          }
+        }
+      };
+
+      new CardView({ // eslint-disable-line no-new
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+
+      expect(hostedFieldsConfiguredFields.cvv).to.not.exist;
+      expect(hostedFieldsConfiguredFields.postalCode).to.not.exist;
+      expect(hostedFieldsConfiguredFields.expirationMonth).to.not.exist;
+      expect(hostedFieldsConfiguredFields.expirationYear).to.not.exist;
+    });
+
+    it('ignores changes to selector in field options', function () {
+      var hostedFieldsConfiguredFields;
+
+      this.model.merchantConfiguration.card = {
+        hostedFieldsOverrides: {
+          fields: {
+            number: {
+              selector: '#some-selector'
+            }
+          }
+        }
+      };
+
+      new CardView({ // eslint-disable-line no-new
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+
+      expect(hostedFieldsConfiguredFields.number.selector).to.not.equal('#some-selector');
+    });
+
+    it('allows overriding styles options for hosted fields', function () {
+      var hostedFieldsConfiguredStyles;
+
+      this.model.merchantConfiguration.card = {
+        hostedFieldsOverrides: {
+          styles: {
+            input: {
+              background: 'blue',
+              color: 'red'
+            },
+            ':focus': null
+          }
+        }
+      };
+
+      new CardView({ // eslint-disable-line no-new
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      hostedFieldsConfiguredStyles = hostedFields.create.lastCall.args[0].styles;
+
+      expect(hostedFieldsConfiguredStyles.input.color).to.equal('red');
+      expect(hostedFieldsConfiguredStyles.input.background).to.equal('blue');
+      expect(hostedFieldsConfiguredStyles.input['font-size']).to.equal('16px');
+      expect(hostedFieldsConfiguredStyles[':focus']).to.not.exist;
+      expect(hostedFieldsConfiguredStyles['input::-ms-clear']).to.deep.equal({
+        color: 'transparent'
+      });
+    });
   });
 
   describe('requestPaymentMethod', function () {
@@ -393,6 +593,7 @@ describe('CardView', function () {
       this.context = {
         element: this.element,
         _generateFieldSelector: CardView.prototype._generateFieldSelector,
+        _generateHostedFieldsOptions: CardView.prototype._generateHostedFieldsOptions,
         _validateForm: this.sandbox.stub(),
         getElementById: BaseView.prototype.getElementById,
         hideFieldError: CardView.prototype.hideFieldError,


### PR DESCRIPTION
### Summary
This allows merchants to customize Hosted Fields through their create call. Particularly helps folks looking to remove inputs not based on their AVS and CVV settings and set a custom minimum length. API looks like:
```
braintree.dropin.create({
  authorization: 'CLIENT_AUTHORIZATION',
  container: '#dropin-container',
  card: {
    overrides: {
      fields: {
        number: {
          placeholder: '1111 1111 1111 1111' // Update the number field placeholder
        },
        postalCode: {
          minlength: 5 // Set the minimum length of the postal code field
        },
        cvv: null // Remove the CVV field from your form
      },
      styles: {
        input: {
          'font-size': '18px' // Change the font size for all inputs
        },
        ':focus': {
          color: 'red' // Change the focus color to red for all inputs
        }
      }
    }
  }
}, callback);
```
![screen shot 2017-05-31 at 10 46 46 am](https://cloud.githubusercontent.com/assets/7514489/26640857/8efa1c7e-45ee-11e7-8a61-5b8303129337.png)


### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
