### PR TITLE
Prevent default in script tag integration before Drop-in is created

### DIFF
--- a/src/lib/create-from-script-tag.js
+++ b/src/lib/create-from-script-tag.js
@@ -26,6 +26,10 @@ function createFromScriptTag(createFunction, scriptTag) {
     throw new DropinError('No form found for script tag integration.');
   }
 
+  form.addEventListener('submit', function (event) {
+    event.preventDefault();
+  });
+
   form.insertBefore(container, scriptTag);
 
   createFunction({
@@ -36,9 +40,7 @@ function createFromScriptTag(createFunction, scriptTag) {
       throw createError;
     }
 
-    form.addEventListener('submit', function (event) {
-      event.preventDefault();
-
+    form.addEventListener('submit', function () {
       instance.requestPaymentMethod(function (requestPaymentError, payload) {
         var paymentMethodNonce;
 

--- a/test/unit/lib/unit/create-from-script-tag.js
+++ b/test/unit/lib/unit/create-from-script-tag.js
@@ -89,7 +89,7 @@ describe('createFromScriptTag', function () {
   it('adds submit listener to form for requesting a payment method', function () {
     createFromScriptTag(this.createFunction, this.scriptTag);
 
-    expect(this.fakeForm.addEventListener).to.be.calledOnce;
+    expect(this.fakeForm.addEventListener).to.be.calledTwice;
     expect(this.fakeForm.addEventListener).to.be.calledWith('submit', this.sandbox.match.func);
   });
 
@@ -108,16 +108,27 @@ describe('createFromScriptTag', function () {
     expect(fakeEvent.preventDefault).to.be.calledOnce;
   });
 
+  it('prevents default form submission before Drop-in is created', function () {
+    var submitHandler;
+    var fakeCreateFunction = this.sandbox.stub();
+    var fakeEvent = {preventDefault: this.sandbox.stub()};
+
+    createFromScriptTag(fakeCreateFunction, this.scriptTag);
+
+    submitHandler = this.fakeForm.addEventListener.getCall(0).args[1];
+
+    submitHandler(fakeEvent);
+
+    expect(fakeEvent.preventDefault).to.be.calledOnce;
+  });
+
   it('calls requestPaymentMethod when form submits', function () {
     var submitHandler;
 
     createFromScriptTag(this.createFunction, this.scriptTag);
 
-    submitHandler = this.fakeForm.addEventListener.getCall(0).args[1];
-
-    submitHandler({
-      preventDefault: this.sandbox.stub()
-    });
+    submitHandler = this.fakeForm.addEventListener.getCall(1).args[1];
+    submitHandler();
 
     expect(this.instance.requestPaymentMethod).to.be.calledOnce;
   });
@@ -130,9 +141,8 @@ describe('createFromScriptTag', function () {
     document.createElement.withArgs('input').returns(fakeInput);
     createFromScriptTag(this.createFunction, this.scriptTag);
 
-    submitHandler = this.fakeForm.addEventListener.getCall(0).args[1];
-
-    submitHandler({preventDefault: this.sandbox.stub()});
+    submitHandler = this.fakeForm.addEventListener.getCall(1).args[1];
+    submitHandler();
 
     expect(this.fakeForm.appendChild).to.be.calledOnce;
     expect(this.fakeForm.appendChild).to.be.calledWith(fakeInput);
@@ -149,9 +159,8 @@ describe('createFromScriptTag', function () {
     this.sandbox.spy(document, 'createElement');
     createFromScriptTag(this.createFunction, this.scriptTag);
 
-    submitHandler = this.fakeForm.addEventListener.getCall(0).args[1];
-
-    submitHandler({preventDefault: this.sandbox.stub()});
+    submitHandler = this.fakeForm.addEventListener.getCall(1).args[1];
+    submitHandler();
 
     expect(document.createElement).to.not.be.calledWith('input');
     expect(this.fakeForm.submit).to.not.be.called;
@@ -166,9 +175,8 @@ describe('createFromScriptTag', function () {
 
     createFromScriptTag(this.createFunction, this.scriptTag);
 
-    submitHandler = this.fakeForm.addEventListener.getCall(0).args[1];
-
-    submitHandler({preventDefault: this.sandbox.stub()});
+    submitHandler = this.fakeForm.addEventListener.getCall(1).args[1];
+    submitHandler();
 
     expect(this.fakeForm.appendChild).to.not.be.called;
     expect(document.createElement).to.not.be.calledWith('input');


### PR DESCRIPTION
### Summary
Adds an event listener with `event.preventDefault` before Drop-in is created with a script tag integration so the form can't be submitted before the form appears.

Open to more elegant solutions. Possible issue could be if Drop-in fails to load, we'll still be preventing default on the form.

### Checklist
~Added a changelog entry~
- [x] Ran unit tests
