### PR TITLE
Add locale support to script tag integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+-----------
+- Add locale to script tag integration
+
 1.3.0
 ------
 - Add script tag integration for cards only

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@
  *   <body>
  *     <form id="payment-form" action="/" method="post">
  *       <script src="https://js.braintreegateway.com/web/dropin/{@pkg version}/js/dropin.min.js"
- *        data-braintree-dropin-authorization="CLIENT_AUTHORIZATION"
+ *         data-braintree-dropin-authorization="CLIENT_AUTHORIZATION"
  *       ></script>
  *       <input type="submit" value="Purchase"></input>
  *     </form>

--- a/src/lib/create-from-script-tag.js
+++ b/src/lib/create-from-script-tag.js
@@ -5,13 +5,14 @@ var uuid = require('./uuid');
 var DropinError = require('./dropin-error');
 
 function createFromScriptTag(createFunction, scriptTag) {
-  var authorization, container, form;
+  var authorization, locale, container, form;
 
   if (!scriptTag) {
     return;
   }
 
   authorization = scriptTag.getAttribute('data-braintree-dropin-authorization');
+  locale = scriptTag.getAttribute('data-locale');
 
   if (!authorization) {
     throw new DropinError('Authorization not found in data-braintree-dropin-authorization attribute');
@@ -34,6 +35,7 @@ function createFromScriptTag(createFunction, scriptTag) {
 
   createFunction({
     authorization: authorization,
+    locale: locale,
     container: container
   }, function (createError, instance) {
     if (createError) {

--- a/test/unit/lib/unit/create-from-script-tag.js
+++ b/test/unit/lib/unit/create-from-script-tag.js
@@ -78,6 +78,16 @@ describe('createFromScriptTag', function () {
     }, this.sandbox.match.func);
   });
 
+  it('calls create with locale if provided', function () {
+    this.scriptTag.getAttribute.withArgs('data-locale').returns('DE');
+    createFromScriptTag(this.createFunction, this.scriptTag);
+
+    expect(this.createFunction).to.be.calledOnce;
+    expect(this.createFunction).to.be.calledWithMatch({
+      locale: 'DE'
+    });
+  });
+
   it('throws an error if instance creation fails', function () {
     this.createFunction.yields(new Error('foo'));
 


### PR DESCRIPTION
### Summary

Adds a `data-locale` attribute to script tag integration.

Not sure what the best way to document this stuff is. Maybe it should have it's own page in JSDoc?

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
