### PR TITLE
Autoprefix CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Autoprefix CSS, fixing issues in older browsers
+
 1.3.0
 ------
 - Add script tag integration for cards only

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,8 @@ var serveStatic = require('serve-static');
 var finalhandler = require('finalhandler');
 var gutil = require('gulp-util');
 var mkdirp = require('mkdirp');
+var autoprefixer = require('gulp-autoprefixer');
+
 var VERSION = require('./package.json').version;
 
 var DIST_PATH = 'dist/web/dropin/' + VERSION;
@@ -93,6 +95,7 @@ gulp.task('build:css', function () {
 
   return gulp.src(config.src.css.main)
     .pipe(sass(sassOptions).on('error', sass.logError))
+    .pipe(autoprefixer())
     .pipe(rename(config.src.css.output))
     .pipe(gulp.dest(config.dist.css))
     .pipe(cleanCSS())

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-config-braintree": "1.0.2",
     "finalhandler": "0.5.0",
     "gulp": "3.9.1",
+    "gulp-autoprefixer": "4.0.0",
     "gulp-brfs": "0.1.0",
     "gulp-clean-css": "2.0.13",
     "gulp-envify": "1.0.0",


### PR DESCRIPTION
### Summary
This adds autoprefixing when we build our CSS, which fixes some issues in older browsers. Specifically older versions of iOS Safari that support flexbox, but require prefixing. 

Reported in issue #197 

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
