### PR TITLE
Add aria attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ unreleased
 ----------
 - Add aria-invalid attribute for cards
 
-
 1.3.0
 ------
 - Add script tag integration for cards only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Add aria-invalid attribute for cards
+
+
 1.3.0
 ------
 - Add script tag integration for cards only

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -290,6 +290,12 @@ CardView.prototype.showFieldError = function (field, errorMessage) {
 
   fieldError = this.fieldErrors[field];
   fieldError.textContent = errorMessage;
+
+  this.hostedFieldsInstance.setAttribute({
+    field: field,
+    attribute: 'aria-invalid',
+    value: true
+  });
 };
 
 CardView.prototype.hideFieldError = function (field) {
@@ -300,6 +306,11 @@ CardView.prototype.hideFieldError = function (field) {
   }
 
   classlist.remove(fieldGroup, 'braintree-form__field-group--has-error');
+
+  this.hostedFieldsInstance.removeAttribute({
+    field: field,
+    attribute: 'aria-invalid'
+  });
 };
 
 CardView.prototype.teardown = function (callback) {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -699,7 +699,8 @@ describe('CardView', function () {
           }
         };
         var hostedFieldsInstance = {
-          on: this.sandbox.stub().callsArgWith(1, fakeEvent)
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setAttribute: this.sandbox.stub()
         };
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
@@ -726,7 +727,8 @@ describe('CardView', function () {
             if (event === 'blur') {
               callback(fakeEvent);
             }
-          }
+          },
+          setAttribute: this.sandbox.stub()
         };
         var numberFieldError = this.element.querySelector('[data-braintree-id="number-field-error"]');
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
@@ -765,7 +767,8 @@ describe('CardView', function () {
         };
         var modelOptions = fake.modelOptions();
         var hostedFieldsInstance = {
-          on: this.sandbox.stub().callsArgWith(1, fakeEvent)
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setAttribute: this.sandbox.stub()
         };
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
         var numberFieldError = this.element.querySelector('[data-braintree-id="number-field-error"]');
@@ -1214,7 +1217,8 @@ describe('CardView', function () {
           }
         };
         var hostedFieldsInstance = {
-          on: this.sandbox.stub().callsArgWith(1, fakeEvent)
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          removeAttribute: this.sandbox.stub()
         };
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
@@ -1244,7 +1248,8 @@ describe('CardView', function () {
             if (event === 'validityChange') {
               callback(fakeEvent);
             }
-          }
+          },
+          removeAttribute: this.sandbox.stub()
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
@@ -1271,7 +1276,8 @@ describe('CardView', function () {
             if (event === 'validityChange') {
               callback(fakeEvent);
             }
-          }
+          },
+          removeAttribute: this.sandbox.stub()
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
@@ -1298,7 +1304,8 @@ describe('CardView', function () {
             if (event === 'validityChange') {
               callback(fakeEvent);
             }
-          }
+          },
+          removeAttribute: this.sandbox.stub()
         };
 
         this.context.client.getConfiguration = function () {
@@ -1336,7 +1343,8 @@ describe('CardView', function () {
             if (event === 'validityChange') {
               callback(fakeEvent);
             }
-          }
+          },
+          removeAttribute: this.sandbox.stub()
         };
 
         this.context.client.getConfiguration = function () {
@@ -1374,7 +1382,8 @@ describe('CardView', function () {
             if (event === 'validityChange') {
               callback(fakeEvent);
             }
-          }
+          },
+          removeAttribute: this.sandbox.stub()
         };
 
         this.context.client.getConfiguration = function () {
@@ -1493,7 +1502,8 @@ describe('CardView', function () {
           }
         };
         var hostedFieldsInstance = {
-          on: this.sandbox.stub().callsArgWith(1, fakeEvent)
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          removeAttribute: this.sandbox.stub()
         };
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
@@ -1522,6 +1532,8 @@ describe('CardView', function () {
             }
           }
         }),
+        removeAttribute: this.sandbox.stub(),
+        setAttribute: this.sandbox.stub(),
         tokenize: this.sandbox.stub()
       };
       this.model = new DropinModel(fake.modelOptions());
@@ -1688,6 +1700,49 @@ describe('CardView', function () {
       expect(numberFieldError.classList.contains('braintree-hidden')).to.be.false;
       expect(numberFieldError.textContent).to.equal('This card number is not valid.');
       expect(this.context.hostedFieldsInstance.tokenize).to.not.be.called;
+    });
+
+    it('sets the aria-invalid attribute when a field error is shown', function () {
+      this.context.hostedFieldsInstance.getState.returns({
+        cards: [{type: 'visa'}],
+        fields: {
+          number: {
+            isValid: false
+          },
+          expirationDate: {
+            isValid: true
+          }
+        }
+      });
+
+      CardView.prototype.showFieldError.call(this.context, 'number');
+
+      expect(this.context.hostedFieldsInstance.setAttribute).to.be.calledWith({
+        field: 'number',
+        attribute: 'aria-invalid',
+        value: true
+      });
+    });
+
+    it('removes the aria-invalid attribute when a field error is hidden', function () {
+      this.context.hostedFieldsInstance.getState.returns({
+        cards: [{type: 'visa'}],
+        fields: {
+          number: {
+            isValid: false
+          },
+          expirationDate: {
+            isValid: true
+          }
+        }
+      });
+
+      CardView.prototype.hideFieldError.call(this.context, 'number');
+
+      expect(this.context.hostedFieldsInstance.removeAttribute).to.be.calledWith({
+        field: 'number',
+        attribute: 'aria-invalid'
+      });
     });
 
     it('calls hostedFieldsInstance.tokenize when form is valid', function () {


### PR DESCRIPTION
### Summary

Add ARIA support for cards. This adds and removes the `aria-invalid` attribute when showing and hiding Hosted Fields errors.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
