### PR TITLE
Fix error when using Hosted Fields overrides to remove CVV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - `dropinInstance.requestPaymentMethod` will return a promise if no callback is provided
 - `dropinInstance.teardown` will return a promise if no callback is provided
 - `dropin.create` will return a promise if no callback is provided
+- Fix error thrown in console when removing fields with card overrides
 
 1.3.1
 -----

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -121,46 +121,46 @@ CardView.prototype._generateHostedFieldsOptions = function () {
     }
   };
 
-  if (overrides) {
-    if (overrides.fields) {
-      if (overrides.fields.cvv && overrides.fields.cvv.placeholder) {
-        this._hasCustomCVVPlaceholder = true;
-      }
-
-      Object.keys(overrides.fields).forEach(function (field) {
-        if ((field === 'cvv' || field === 'postalCode') && overrides.fields[field] === null) {
-          delete options.fields[field];
-          return;
-        }
-
-        if (!options.fields[field]) {
-          return;
-        }
-
-        assign(options.fields[field], overrides.fields[field], {
-          selector: options.fields[field].selector
-        });
-      });
-    }
-
-    if (overrides.styles) {
-      Object.keys(overrides.styles).forEach(function (style) {
-        if (overrides.styles[style] === null) {
-          delete options.styles[style];
-          return;
-        }
-
-        assign(options.styles[style], overrides.styles[style]);
-      });
-    }
-  }
-
   if (!hasCVVChallenge) {
     delete options.fields.cvv;
   }
 
   if (!hasPostalCodeChallenge) {
     delete options.fields.postalCode;
+  }
+
+  if (!overrides) { return options; }
+
+  if (overrides.fields) {
+    if (overrides.fields.cvv && overrides.fields.cvv.placeholder) {
+      this._hasCustomCVVPlaceholder = true;
+    }
+
+    Object.keys(overrides.fields).forEach(function (field) {
+      if ((field === 'cvv' || field === 'postalCode') && overrides.fields[field] === null) {
+        delete options.fields[field];
+        return;
+      }
+
+      if (!options.fields[field]) {
+        return;
+      }
+
+      assign(options.fields[field], overrides.fields[field], {
+        selector: options.fields[field].selector
+      });
+    });
+  }
+
+  if (overrides.styles) {
+    Object.keys(overrides.styles).forEach(function (style) {
+      if (overrides.styles[style] === null) {
+        delete options.styles[style];
+        return;
+      }
+
+      assign(options.styles[style], overrides.styles[style]);
+    });
   }
 
   return options;

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -25,15 +25,12 @@ CardView.ID = CardView.prototype.ID = constants.paymentOptionIDs.card;
 CardView.prototype._initialize = function () {
   var cvvFieldGroup, postalCodeFieldGroup;
   var cardIcons = this.getElementById('card-view-icons');
-  var challenges = this.client.getConfiguration().gatewayConfiguration.challenges;
-  var hasCVV = challenges.indexOf('cvv') !== -1;
-  var hasPostal = challenges.indexOf('postal_code') !== -1;
   var hfOptions = this._generateHostedFieldsOptions();
 
   cardIcons.innerHTML = cardIconHTML;
   this._hideUnsupportedCardIcons();
 
-  this.hasCVV = hasCVV;
+  this.hasCVV = hfOptions.fields.cvv;
   this.cardNumberIcon = this.getElementById('card-number-icon');
   this.cardNumberIconSvg = this.getElementById('card-number-icon-svg');
   this.cvvIcon = this.getElementById('cvv-icon');
@@ -41,17 +38,14 @@ CardView.prototype._initialize = function () {
   this.cvvLabelDescriptor = this.getElementById('cvv-label-descriptor');
   this.fieldErrors = {};
 
-  if (!hasCVV || !hfOptions.fields.cvv) {
+  if (!hfOptions.fields.cvv) {
     cvvFieldGroup = this.getElementById('cvv-field-group');
-
     cvvFieldGroup.parentNode.removeChild(cvvFieldGroup);
-    delete hfOptions.fields.cvv;
   }
-  if (!hasPostal || !hfOptions.fields.postalCode) {
-    postalCodeFieldGroup = this.getElementById('postal-code-field-group');
 
+  if (!hfOptions.fields.postalCode) {
+    postalCodeFieldGroup = this.getElementById('postal-code-field-group');
     postalCodeFieldGroup.parentNode.removeChild(postalCodeFieldGroup);
-    delete hfOptions.fields.postalCode;
   }
 
   this.model.asyncDependencyStarting();
@@ -77,6 +71,9 @@ CardView.prototype._initialize = function () {
 };
 
 CardView.prototype._generateHostedFieldsOptions = function () {
+  var challenges = this.client.getConfiguration().gatewayConfiguration.challenges;
+  var hasCVVChallenge = challenges.indexOf('cvv') !== -1;
+  var hasPostalCodeChallenge = challenges.indexOf('postal_code') !== -1;
   var overrides = this.model.merchantConfiguration.card && this.model.merchantConfiguration.card.overrides;
   var options = {
     client: this.client,
@@ -124,40 +121,46 @@ CardView.prototype._generateHostedFieldsOptions = function () {
     }
   };
 
-  if (!overrides) {
-    return options;
-  }
+  if (overrides) {
+    if (overrides.fields) {
+      if (overrides.fields.cvv && overrides.fields.cvv.placeholder) {
+        this._hasCustomCVVPlaceholder = true;
+      }
 
-  if (overrides.fields) {
-    if (overrides.fields.cvv && overrides.fields.cvv.placeholder) {
-      this._hasCustomCVVPlaceholder = true;
+      Object.keys(overrides.fields).forEach(function (field) {
+        if ((field === 'cvv' || field === 'postalCode') && overrides.fields[field] === null) {
+          delete options.fields[field];
+          return;
+        }
+
+        if (!options.fields[field]) {
+          return;
+        }
+
+        assign(options.fields[field], overrides.fields[field], {
+          selector: options.fields[field].selector
+        });
+      });
     }
 
-    Object.keys(overrides.fields).forEach(function (field) {
-      if ((field === 'cvv' || field === 'postalCode') && overrides.fields[field] === null) {
-        delete options.fields[field];
-        return;
-      }
+    if (overrides.styles) {
+      Object.keys(overrides.styles).forEach(function (style) {
+        if (overrides.styles[style] === null) {
+          delete options.styles[style];
+          return;
+        }
 
-      if (!options.fields[field]) {
-        return;
-      }
-
-      assign(options.fields[field], overrides.fields[field], {
-        selector: options.fields[field].selector
+        assign(options.styles[style], overrides.styles[style]);
       });
-    });
+    }
   }
 
-  if (overrides.styles) {
-    Object.keys(overrides.styles).forEach(function (style) {
-      if (overrides.styles[style] === null) {
-        delete options.styles[style];
-        return;
-      }
+  if (!hasCVVChallenge) {
+    delete options.fields.cvv;
+  }
 
-      assign(options.styles[style], overrides.styles[style]);
-    });
+  if (!hasPostalCodeChallenge) {
+    delete options.fields.postalCode;
   }
 
   return options;

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -38,7 +38,7 @@ CardView.prototype._initialize = function () {
   this.cvvLabelDescriptor = this.getElementById('cvv-label-descriptor');
   this.fieldErrors = {};
 
-  if (!hfOptions.fields.cvv) {
+  if (!this.hasCVV) {
     cvvFieldGroup = this.getElementById('cvv-field-group');
     cvvFieldGroup.parentNode.removeChild(cvvFieldGroup);
   }

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -1144,7 +1144,7 @@ describe('CardView', function () {
         expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
       });
 
-      it('does not update the cvv field placeholder when cvv field does not exist', function () {
+      it('does not update the cvv field placeholder when there is no cvv challenge', function () {
         var fakeEvent = {
           cards: [{type: 'american-express'}, {type: 'visa'}],
           emittedBy: 'number'
@@ -1163,6 +1163,30 @@ describe('CardView', function () {
               }
             }
           };
+        };
+
+        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        CardView.prototype._initialize.call(this.context);
+
+        expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
+      });
+
+      it('does not update the cvv field placeholder when it is removed with an override', function () {
+        var fakeEvent = {
+          cards: [{type: 'american-express'}, {type: 'visa'}],
+          emittedBy: 'number'
+        };
+        var hostedFieldsInstance = {
+          on: this.sandbox.stub().callsArgWith(1, fakeEvent),
+          setAttribute: this.sandbox.spy()
+        };
+
+        this.context.model.merchantConfiguration.card = {
+          overrides: {
+            fields: {
+              cvv: null
+            }
+          }
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);


### PR DESCRIPTION
### Summary

Fixes a bug where errors in the console appeared when removing the CVV field with Hosted Fields overrides. We were trying to update the cvv placeholder and such even when that field did not exist.

Diff has a lot of moves because I moved the CVV challenges logic into the `_generateHostedFieldsOptions` method.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
