### PR TITLE
Add payment option chosen event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - `dropinInstance.requestPaymentMethod` will return a promise if no callback is provided
 - `dropinInstance.teardown` will return a promise if no callback is provided
 - `dropin.create` will return a promise if no callback is provided
+- Add `paymentOptionChosen` event
 
 1.3.1
 -----

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -59,6 +59,12 @@ DropinModel.prototype.changeActivePaymentView = function (paymentViewID) {
   this._emit('changeActivePaymentView', paymentViewID);
 };
 
+DropinModel.prototype.selectPaymentOption = function (paymentViewID) {
+  this._emit('paymentOptionSelected', {
+    paymentOption: paymentViewID
+  });
+};
+
 DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
   var requestableStateHasNotChanged = this.isPaymentMethodRequestable() === options.isRequestable;
   var typeHasNotChanged = options.type === this._paymentMethodRequestableType;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -106,6 +106,18 @@ var VERSION = process.env.npm_package_version;
  */
 
 /**
+ * This event is emitted when a payment option is selected by the customer.
+ * @event Dropin#paymentOptionSelected
+ * @type {Dropin~paymentOptionSelectedPayload}
+ */
+
+/**
+ * @typedef {object} Dropin~paymentOptionSelectedPayload
+ * @description The event payload sent from {@link Dropin#on|`on`} with the {@link Dropin#event:paymentOptionSelected|`paymentOptionSelected`} event.
+ * @property {string} paymentOption The payment option view selected. Either `card`, `paypal`, or `paypalCredit`.
+ */
+
+/**
  * @class
  * @param {object} options For create options, see {@link module:braintree-web-drop-in|dropin.create}.
  * @description <strong>Do not use this constructor directly. Use {@link module:braintree-web-drop-in|dropin.create} instead.</strong>
@@ -217,6 +229,10 @@ Dropin.prototype._initialize = function (callback) {
 
     this._model.on('noPaymentMethodRequestable', function () {
       this._emit('noPaymentMethodRequestable');
+    }.bind(this));
+
+    this._model.on('paymentOptionSelected', function (event) {
+      this._emit('paymentOptionSelected', event);
     }.bind(this));
 
     function createMainView() {

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -32,6 +32,7 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
   var html = paymentMethodOptionHTML;
   var clickHandler = function clickHandler() {
     this.mainView.setPrimaryView(paymentOptionID);
+    this.model.selectPaymentOption(paymentOptionID);
     analytics.sendEvent(this.client, 'selected.' + paymentOptionIDs[paymentOptionID]);
   }.bind(this);
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -190,6 +190,12 @@
         payButton.removeAttribute('disabled');
       }
 
+      if (!config.disablePaymentOptionSelectedListener) {
+        instance.on('paymentOptionSelected', function (event) {
+          console.log(event.paymentOption, 'selected.');
+        });
+      }
+
       teardownButton.removeAttribute('disabled');
       createButton.setAttribute('disabled', true);
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -588,4 +588,21 @@ describe('DropinModel', function () {
       expect(this.model._paymentMethodRequestableType).to.not.exist;
     });
   });
+
+  describe('selectPaymentOption', function () {
+    beforeEach(function () {
+      this.model = new DropinModel(this.modelOptions);
+
+      this.sandbox.stub(this.model, '_emit');
+    });
+
+    it('emits a paymentOptionSelected event with the id of the payment option that was selected', function () {
+      this.model.selectPaymentOption('card');
+
+      expect(this.model._emit).to.be.calledOnce;
+      expect(this.model._emit).to.be.calledWith('paymentOptionSelected', {
+        paymentOption: 'card'
+      });
+    });
+  });
 });

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1028,6 +1028,22 @@ describe('Dropin', function () {
     });
   });
 
+  describe('payemnt option selected event', function () {
+    it('emits paymentOptionSelected when the model emits paymentOptionSelected', function (done) {
+      var instance = new Dropin(this.dropinOptions);
+
+      instance.on('paymentOptionSelected', function (event) {
+        expect(event.paymentOption).to.equal('Foo');
+
+        done();
+      });
+
+      instance._initialize(function () {
+        instance._model._emit('paymentOptionSelected', {paymentOption: 'Foo'});
+      });
+    });
+  });
+
   describe('_loadPayPalScript', function () {
     function noop() {}
 

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1028,7 +1028,7 @@ describe('Dropin', function () {
     });
   });
 
-  describe('payemnt option selected event', function () {
+  describe('payment option selected event', function () {
     it('emits paymentOptionSelected when the model emits paymentOptionSelected', function (done) {
       var instance = new Dropin(this.dropinOptions);
 

--- a/test/unit/views/payment-options-view.js
+++ b/test/unit/views/payment-options-view.js
@@ -107,6 +107,24 @@ describe('PaymentOptionsView', function () {
 
       expect(mainViewStub.setPrimaryView).to.have.been.calledWith(CardView.ID);
     });
+
+    it('calls model.selectPaymentOption when payment option is clicked', function () {
+      var mainViewStub = {setPrimaryView: this.sandbox.stub()};
+      var paymentOptionsView = new PaymentOptionsView({
+        client: this.client,
+        element: this.element,
+        mainView: mainViewStub,
+        model: modelThatSupports(['card']),
+        strings: strings
+      });
+      var option = paymentOptionsView.container.querySelector('.braintree-option');
+
+      this.sandbox.stub(paymentOptionsView.model, 'selectPaymentOption');
+
+      option.click();
+
+      expect(paymentOptionsView.model.selectPaymentOption).to.have.been.calledWith(CardView.ID);
+    });
   });
 
   describe('sends analytics events', function () {


### PR DESCRIPTION
closes #212

### Summary

Adds event for when a payment option is chosen.

```js
dropinInstance.on('paymentOptionSelected', function (event) {
  console.log(event.paymentOption, 'selected.'); // card, paypal, paypalCredit
});
```

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
