### PR TITLE
Fix error where drop-in would not finish transition if inside a hidden container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ unreleased
 - `dropinInstance.teardown` will return a promise if no callback is provided
 - `dropin.create` will return a promise if no callback is provided
 - Fix error thrown in console when removing fields with card overrides
+- Fix bug where Drop-in would not finish loading if inside a hidden div
 
 1.3.1
 -----

--- a/src/lib/transition-helper.js
+++ b/src/lib/transition-helper.js
@@ -2,8 +2,20 @@
 
 var browserDetection = require('./browser-detection');
 
+function isHidden(element) {
+  if (!element) { // no parentNode, so nothing containing the element is hidden
+    return false;
+  }
+
+  if (element.style.display === 'none') {
+    return true;
+  }
+
+  return isHidden(element.parentNode);
+}
+
 function onTransitionEnd(element, propertyName, callback) {
-  if (browserDetection.isIe9()) {
+  if (browserDetection.isIe9() || isHidden(element)) {
     callback();
     return;
   }

--- a/test/unit/lib/unit/transition-helper.js
+++ b/test/unit/lib/unit/transition-helper.js
@@ -17,6 +17,26 @@ describe('onTransitionEnd', function () {
     onTransitionEnd(element, this.fakePropertyName, done);
   });
 
+  it('immediately calls callback when element has display: none', function (done) {
+    var element = document.createElement('div');
+
+    element.style.display = 'none';
+
+    onTransitionEnd(element, this.fakePropertyName, done);
+  });
+
+  it('immediately calls callback when a parent element has display: none', function (done) {
+    var topLevelElement = document.createElement('div');
+    var middleElement = document.createElement('div');
+    var element = document.createElement('div');
+
+    topLevelElement.style.display = 'none';
+    middleElement.appendChild(element);
+    topLevelElement.appendChild(middleElement);
+
+    onTransitionEnd(element, this.fakePropertyName, done);
+  });
+
   it('calls callback after onTransitionEnd end when the event propertyName matches', function (done) {
     var element = document.createElement('div');
 


### PR DESCRIPTION
closes #210

### Summary

The transition end listener never fires if the drop-in is inside a hidden container. This means that some parts of the drop-in are obscured by an invisible loader div that never gets cleaned up.

This adds a simple check if the element containing drop-in, or a parent is hidden and skips the transition listener.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
