### PR TITLE
Update braintree-web to 3.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ unreleased
 - `dropin.create` will return a promise if no callback is provided
 - Fix error thrown in console when removing fields with card overrides
 - Fix bug where Drop-in would not finish loading if inside a hidden div
+- Use version 3.19.1 of braintree-web
 
 1.3.1
 -----

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.19.0",
+    "braintree-web": "3.19.1",
     "@braintree/browser-detection": "1.4.1",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary

Bump braintree.js to 3.19.1

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests