### PR TITLE
Older iOS Safari fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ unreleased
 - `dropin.create` will return a promise if no callback is provided
 - Fix error thrown in console when removing fields with card overrides
 - Fix bug where Drop-in would not finish loading if inside a hidden div
+- Improve UI in older versions of iOS Safari
 
 1.3.1
 -----

--- a/package.json
+++ b/package.json
@@ -73,5 +73,9 @@
         }
       ]
     ]
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "iOS 8"
+  ]
 }

--- a/spec/sauce_helper.rb
+++ b/spec/sauce_helper.rb
@@ -23,7 +23,8 @@ def select_browsers
       # ["OS X 10.11", "safari", nil],
       ["Windows 7", "internet explorer", "9"],
       ["Windows 8", "internet explorer", "10"],
-      ["Windows 10", "internet explorer", "11"],
+      # Sauce is having problems logging in for PayPal Checkout in Windows 10
+      ["Windows 8.1", "internet explorer", "11"],
     ]
   end
 

--- a/src/html/payment-method.html
+++ b/src/html/payment-method.html
@@ -8,7 +8,7 @@
 
 <div class="braintree-method__check-container">
   <div class="braintree-method__check">
-    <svg height="30" width="50">
+    <svg height="100%" width="100%">
       <use xlink:href="#iconCheck"></use>
     </svg>
   </div>

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -645,7 +645,7 @@ $loader-scale-duration: 300ms;
     fill: $background-color;
     height: 41px;
     margin-right: 7px;
-    padding: 7px 10px 10px;
+    padding: 10px;
     transform: scale(0);
     transition: transform 300ms $curve-easeOutBack;
     width: 41px;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -206,6 +206,7 @@ $loader-scale-duration: 300ms;
 }
 
 .braintree-loaded .braintree-upper-container {
+  min-height: inherit;
   min-height: auto;
 
   &:before {


### PR DESCRIPTION
### Summary
Fixes a number of UI oddities in older versions of iOS Safari:
- Check not centered in green checkbox in PaymentMethodViews
- Card icons overlap CardView label
- Fields do not align when CVV and postal code are included
- Gap between payment method views and toggle

Also uses Windows 8.1 for IE 11 integration tests because of the PayPal Checkout/Sauce issue.

### Checklist

- [x] Added a changelog entry
- [x] Ran unit tests
