### PR TITLE
Add optional selectedPaymentMethod when emitting paymentMethodRequestable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ unreleased
 - Fix bug where Drop-in would not finish loading if inside a hidden div
 - Improve transition from payment sheet views to payment methods view
 - Use version 3.19.1 of braintree-web
+- Add `selectedPaymentMethod` property on `paymentMethodRequestable` events if applicable
 
 1.3.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ unreleased
 - Fix bug where Drop-in would not finish loading if inside a hidden div
 - Improve transition from payment sheet views to payment methods view
 - Use version 3.19.1 of braintree-web
-- Add `selectedPaymentMethod` property on `paymentMethodRequestable` events if applicable
+- Add `isPaymentMethodSelected` property on `paymentMethodRequestable` events
 - Improve UI in older versions of iOS Safari
 
 1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
 - Fix bug where Drop-in would not finish loading if inside a hidden div
 - Improve transition from payment sheet views to payment methods view
 - Use version 3.19.1 of braintree-web
-- Add `isPaymentMethodSelected` property on `paymentMethodRequestable` events
+- Add `paymentMethodIsSelected` property on `paymentMethodRequestable` events
 - Improve UI in older versions of iOS Safari
 
 1.3.1

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -79,14 +79,11 @@ DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
 DropinModel.prototype.setPaymentMethodRequestable = function (options) {
   var shouldEmitEvent = this._shouldEmitRequestableEvent(options);
   var paymentMethodRequestableResponse = {
+    isPaymentMethodSelected: Boolean(options.selectedPaymentMethod),
     type: options.type
   };
 
   this._paymentMethodIsRequestable = options.isRequestable;
-
-  if (options.selectedPaymentMethod) {
-    paymentMethodRequestableResponse.selectedPaymentMethod = options.selectedPaymentMethod;
-  }
 
   if (options.isRequestable) {
     this._paymentMethodRequestableType = options.type;

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -78,8 +78,15 @@ DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
 
 DropinModel.prototype.setPaymentMethodRequestable = function (options) {
   var shouldEmitEvent = this._shouldEmitRequestableEvent(options);
+  var paymentMethodRequestableResponse = {
+    type: options.type
+  };
 
   this._paymentMethodIsRequestable = options.isRequestable;
+
+  if (options.selectedPaymentMethod) {
+    paymentMethodRequestableResponse.selectedPaymentMethod = options.selectedPaymentMethod;
+  }
 
   if (options.isRequestable) {
     this._paymentMethodRequestableType = options.type;
@@ -92,7 +99,7 @@ DropinModel.prototype.setPaymentMethodRequestable = function (options) {
   }
 
   if (options.isRequestable) {
-    this._emit('paymentMethodRequestable', {type: options.type});
+    this._emit('paymentMethodRequestable', paymentMethodRequestableResponse);
   } else {
     this._emit('noPaymentMethodRequestable');
   }

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -79,7 +79,7 @@ DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
 DropinModel.prototype.setPaymentMethodRequestable = function (options) {
   var shouldEmitEvent = this._shouldEmitRequestableEvent(options);
   var paymentMethodRequestableResponse = {
-    isPaymentMethodSelected: Boolean(options.selectedPaymentMethod),
+    paymentMethodIsSelected: Boolean(options.selectedPaymentMethod),
     type: options.type
   };
 

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -81,7 +81,7 @@ var VERSION = process.env.npm_package_version;
  *
  *   dropinInstance.on('paymentMethodRequestable', function (event) {
  *     console.log(event.type); // The type of Payment Method, e.g 'CreditCard', 'PayPalAccount'.
- *     console.log(event.isPaymentMethodSelected); // true if a customer has selected a payment method when paymentMethodRequestable fires
+ *     console.log(event.paymentMethodIsSelected); // true if a customer has selected a payment method when paymentMethodRequestable fires
  *
  *     submitButton.removeAttribute('disabled');
  *   });
@@ -118,7 +118,7 @@ var VERSION = process.env.npm_package_version;
  *     // nonce right away. Otherwise, we wait for the customer to
  *     // request the nonce by pressing the submit button once they
  *     // are finished entering their credit card details
- *     if (event.isPaymentMethodSelected) {
+ *     if (event.paymentMethodIsSelected) {
  *       sendNonceToServer();
  *     }
  *   });
@@ -135,7 +135,7 @@ var VERSION = process.env.npm_package_version;
  * @typedef {object} Dropin~paymentMethodRequestablePayload
  * @description The event payload sent from {@link Dropin#on|`on`} with the {@link Dropin#event:paymentMethodRequestable|`paymentMethodRequestable`} event.
  * @property {string} type The type of payment method that is requestable. Either `CreditCard` or `PayPalAccount`.
- * @property {boolean} isPaymentMethodSelected A property to determine if a payment method is currently selected when the payment method becomes requestable.
+ * @property {boolean} paymentMethodIsSelected A property to determine if a payment method is currently selected when the payment method becomes requestable.
  *
  * This will be `true` any time a payment method is visably selected in the Drop-in UI, such as when PayPal authentication completes or a stored payment method is selected.
  *

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -53,7 +53,7 @@ var VERSION = process.env.npm_package_version;
  * @function
  * @param {string} event The name of the event to which you are subscribing.
  * @param {function} handler A callback to handle the event.
- * @description Subscribes a handler function to a named event. `event` should be {@link HostedFields#event:paymentMethodRequestable|`paymentMethodRequestable`} or {@link HostedFields#event:noPaymentMethodRequestable|`noPaymentMethodRequestable`}.
+ * @description Subscribes a handler function to a named event. `event` should be {@link Dropin~paymentMethodRequestablePayload|`paymentMethodRequestable`} or {@link Dropin~noPaymentMethodRequestablePayload|`noPaymentMethodRequestable`}.
  * @returns {void}
  * @example
  * <caption>Dynamically enable or disable your submit button based on whether or not the payment method is requestable</caption>
@@ -98,6 +98,7 @@ var VERSION = process.env.npm_package_version;
  * @typedef {object} Dropin~paymentMethodRequestablePayload
  * @description The event payload sent from {@link Dropin#on|`on`} with the {@link Dropin#event:paymentMethodRequestable|`paymentMethodRequestable`} event.
  * @property {string} type The type of payment method that is requestable. Either `CreditCard` or `PayPalAccount`.
+ * @property {?Object} selectedPaymentMethod The payment method payload, either {@link Dropin~cardPaymentMethodPayload|`cardPaymentMethodPayload`} or {@link Dropin~paypalPaymentMethodPayload|`paypalPaymentMethodPayload`}. If this property does not exist, call {@link Dropin#requestPaymentMethod|`requestPaymentMethod`} to request the payment method.
  */
 
 /**

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -78,6 +78,7 @@ var VERSION = process.env.npm_package_version;
  *
  *   dropinInstance.on('paymentMethodRequestable', function (event) {
  *     console.log(event.type); // The type of Payment Method, e.g 'CreditCard', 'PayPalAccount'.
+ *     console.log(event.selectedPaymentMethod); // If available, the payment method object.
  *
  *     submitButton.removeAttribute('disabled');
  *   });

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -170,7 +170,8 @@ MainView.prototype.setPrimaryView = function (id, secondaryViewId) {
 
   this.model.setPaymentMethodRequestable({
     isRequestable: Boolean(paymentMethod),
-    type: paymentMethod && paymentMethod.type
+    type: paymentMethod && paymentMethod.type,
+    selectedPaymentMethod: paymentMethod
   });
 
   this.model.clearError();

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -181,10 +181,12 @@
 
         instance.on('paymentMethodRequestable', function (event) {
           payButton.removeAttribute('disabled');
+          console.log('paymentMethodRequestable', event);
         });
 
         instance.on('noPaymentMethodRequestable', function (event) {
           payButton.setAttribute('disabled', true);
+          console.log('noPaymentMethodRequestable');
         });
       } else {
         payButton.removeAttribute('disabled');
@@ -192,7 +194,7 @@
 
       if (!config.disablePaymentOptionSelectedListener) {
         instance.on('paymentOptionSelected', function (event) {
-          console.log(event.paymentOption, 'selected.');
+          console.log('paymentOptionSelected', event.paymentOption);
         });
       }
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -158,6 +158,15 @@
     return config;
   }
 
+  function log() {
+    if (!console || !console.log) {
+      // in IE without dev tools open
+      return;
+    }
+
+    console.log.apply(window, arguments);
+  }
+
   function createDropin () {
     var config = getDropinConfig();
 
@@ -181,12 +190,12 @@
 
         instance.on('paymentMethodRequestable', function (event) {
           payButton.removeAttribute('disabled');
-          console.log('paymentMethodRequestable', event);
+          log('paymentMethodRequestable', event);
         });
 
         instance.on('noPaymentMethodRequestable', function (event) {
           payButton.setAttribute('disabled', true);
-          console.log('noPaymentMethodRequestable');
+          log('noPaymentMethodRequestable');
         });
       } else {
         payButton.removeAttribute('disabled');
@@ -194,7 +203,7 @@
 
       if (!config.disablePaymentOptionSelectedListener) {
         instance.on('paymentOptionSelected', function (event) {
-          console.log('paymentOptionSelected', event.paymentOption);
+          log('paymentOptionSelected', event.paymentOption);
         });
       }
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -97,6 +97,11 @@
 <script src="web/dropin/dev/js/dropin.js"></script>
 
 <script>
+  // IE9 doesn't have console defined unless the dev tools are open
+  window.console = window.console || {};
+  window.console.log = window.console.log || function () {};
+</script>
+<script>
   var defaultCreateObject = {
     // If you are copying this demo app for your integration,
     // use your own client token or tokenization key
@@ -158,15 +163,6 @@
     return config;
   }
 
-  function log() {
-    if (!console || !console.log) {
-      // in IE without dev tools open
-      return;
-    }
-
-    console.log.apply(window, arguments);
-  }
-
   function createDropin () {
     var config = getDropinConfig();
 
@@ -190,12 +186,12 @@
 
         instance.on('paymentMethodRequestable', function (event) {
           payButton.removeAttribute('disabled');
-          log('paymentMethodRequestable', event);
+          console.log('paymentMethodRequestable', event);
         });
 
         instance.on('noPaymentMethodRequestable', function (event) {
           payButton.setAttribute('disabled', true);
-          log('noPaymentMethodRequestable');
+          console.log('noPaymentMethodRequestable');
         });
       } else {
         payButton.removeAttribute('disabled');
@@ -203,7 +199,7 @@
 
       if (!config.disablePaymentOptionSelectedListener) {
         instance.on('paymentOptionSelected', function (event) {
-          log('paymentOptionSelected', event.paymentOption);
+          console.log('paymentOptionSelected', event.paymentOption);
         });
       }
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -503,7 +503,8 @@ describe('DropinModel', function () {
 
       expect(this.model._emit).to.be.calledOnce;
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
-        type: 'card'
+        type: 'card',
+        isPaymentMethodSelected: false
       });
     });
 
@@ -574,7 +575,8 @@ describe('DropinModel', function () {
 
       expect(this.model._emit).to.be.calledOnce;
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
-        type: 'ANOTHER_TYPE'
+        type: 'ANOTHER_TYPE',
+        isPaymentMethodSelected: false
       });
     });
 
@@ -588,7 +590,7 @@ describe('DropinModel', function () {
       expect(this.model._paymentMethodRequestableType).to.not.exist;
     });
 
-    it('includes the selectedPaymentMethod if one is provided', function () {
+    it('includes the isPaymentMethodSelected as true if Drop-in displays a selected payment method', function () {
       var selectedPaymentMethod = {foo: 'bar'};
 
       this.model.setPaymentMethodRequestable({
@@ -599,18 +601,19 @@ describe('DropinModel', function () {
 
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
         type: 'TYPE',
-        selectedPaymentMethod: selectedPaymentMethod
+        isPaymentMethodSelected: true
       });
     });
 
-    it('does not include selectedPaymentMethod when not provided', function () {
+    it('includes the isPaymentMethodSelected as false if no payment method is actively selected', function () {
       this.model.setPaymentMethodRequestable({
         isRequestable: true,
         type: 'TYPE'
       });
 
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
-        type: 'TYPE'
+        type: 'TYPE',
+        isPaymentMethodSelected: false
       });
     });
   });

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -504,7 +504,7 @@ describe('DropinModel', function () {
       expect(this.model._emit).to.be.calledOnce;
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
         type: 'card',
-        isPaymentMethodSelected: false
+        paymentMethodIsSelected: false
       });
     });
 
@@ -576,7 +576,7 @@ describe('DropinModel', function () {
       expect(this.model._emit).to.be.calledOnce;
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
         type: 'ANOTHER_TYPE',
-        isPaymentMethodSelected: false
+        paymentMethodIsSelected: false
       });
     });
 
@@ -590,7 +590,7 @@ describe('DropinModel', function () {
       expect(this.model._paymentMethodRequestableType).to.not.exist;
     });
 
-    it('includes the isPaymentMethodSelected as true if Drop-in displays a selected payment method', function () {
+    it('includes the paymentMethodIsSelected as true if Drop-in displays a selected payment method', function () {
       var selectedPaymentMethod = {foo: 'bar'};
 
       this.model.setPaymentMethodRequestable({
@@ -601,11 +601,11 @@ describe('DropinModel', function () {
 
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
         type: 'TYPE',
-        isPaymentMethodSelected: true
+        paymentMethodIsSelected: true
       });
     });
 
-    it('includes the isPaymentMethodSelected as false if no payment method is actively selected', function () {
+    it('includes the paymentMethodIsSelected as false if no payment method is actively selected', function () {
       this.model.setPaymentMethodRequestable({
         isRequestable: true,
         type: 'TYPE'
@@ -613,7 +613,7 @@ describe('DropinModel', function () {
 
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
         type: 'TYPE',
-        isPaymentMethodSelected: false
+        paymentMethodIsSelected: false
       });
     });
   });

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -587,6 +587,32 @@ describe('DropinModel', function () {
 
       expect(this.model._paymentMethodRequestableType).to.not.exist;
     });
+
+    it('includes the selectedPaymentMethod if one is provided', function () {
+      var selectedPaymentMethod = {foo: 'bar'};
+
+      this.model.setPaymentMethodRequestable({
+        isRequestable: true,
+        type: 'TYPE',
+        selectedPaymentMethod: selectedPaymentMethod
+      });
+
+      expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
+        type: 'TYPE',
+        selectedPaymentMethod: selectedPaymentMethod
+      });
+    });
+
+    it('does not include selectedPaymentMethod when not provided', function () {
+      this.model.setPaymentMethodRequestable({
+        isRequestable: true,
+        type: 'TYPE'
+      });
+
+      expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
+        type: 'TYPE'
+      });
+    });
   });
 
   describe('selectPaymentOption', function () {

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -381,16 +381,21 @@ describe('MainView', function () {
     });
 
     it('calls setPaymentMethodRequestable when there is a payment method requestable', function () {
+      var fakePaymentMethod = {
+        type: 'TYPE',
+        nonce: 'some-nonce'
+      };
       var mainView = new MainView(this.mainViewOptions);
 
-      this.sandbox.stub(BaseView.prototype, 'getPaymentMethod').returns({type: 'TYPE'});
+      this.sandbox.stub(BaseView.prototype, 'getPaymentMethod').returns(fakePaymentMethod);
       this.sandbox.stub(mainView.model, 'setPaymentMethodRequestable');
 
       mainView.setPrimaryView(PaymentOptionsView.ID);
 
       expect(mainView.model.setPaymentMethodRequestable).to.be.calledWith({
         isRequestable: true,
-        type: 'TYPE'
+        type: 'TYPE',
+        selectedPaymentMethod: fakePaymentMethod
       });
     });
 


### PR DESCRIPTION
### Summary
When emitting `paymentMethodRequestable` events we can now optionally send the `selectedPaymentMethod` back as well. 

This is optionally sent back because some `paymentMethodRequestable` events do not yet have the payment method such as when the card form is in a valid state.

Fixes #211 

### Checklist

- [X] Added a changelog entry
- [X] Ran unit tests
