### PR TITLE
Test shared dependencies are the same version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "npm run lint",
     "test": "karma start test/config/karma.js --single-run",
     "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
-    "test:publishing": "npm run pretest && ./node_modules/mocha/bin/mocha test/publishing",
+    "test:publishing": "npm run pretest && mocha test/publishing",
     "deploy:gh-pages": "./scripts/deploy-gh-pages"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "karma start test/config/karma.js --single-run",
     "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
     "test:publishing": "npm run pretest && mocha test/publishing",
-    "deploy:gh-pages": "./scripts/deploy-gh-pages"
+    "deploy:gh-pages": "./scripts/deploy-gh-pages",
+    "prepublish": "npm run test:publishing"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "pretest": "npm run lint",
     "test": "karma start test/config/karma.js --single-run",
     "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
+    "test:publishing": "npm run pretest && ./node_modules/mocha/bin/mocha test/publishing",
     "deploy:gh-pages": "./scripts/deploy-gh-pages"
   },
   "repository": {

--- a/test/config/karma.js
+++ b/test/config/karma.js
@@ -27,6 +27,9 @@ module.exports = function (config) {
     files: [
       '**/*.js'
     ],
-    exclude: ['**/*.swp']
+    exclude: [
+      '**/*.swp',
+      '**/publishing/*.js'
+    ]
   });
 };

--- a/test/publishing/dependency-check.js
+++ b/test/publishing/dependency-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dependencies = require('../../package.json').dependencies;
+var dependencyNames = Object.keys(dependencies);
+var packages = dependencyNames.filter(function (d) {
+  // Remove scoped packages
+  return d[0] !== '@';
+});
+
+describe('Shared dependency', function () {
+  packages.forEach(function (pkgName) {
+    describe(pkgName, function () {
+      var pkgDependencies = require('../../node_modules/' + pkgName + '/package.json').dependencies;
+      var sharedDependencyNames = Object.keys(pkgDependencies).filter(function (d) {
+        return dependencyNames.indexOf(d) !== -1;
+      });
+
+      sharedDependencyNames.forEach(function (sharedDepName) {
+        var sharedDepVersion = pkgDependencies[sharedDepName];
+
+        it('uses ' + sharedDepName + '@' + sharedDepVersion, function () {
+          var dependencyVersion = dependencies[sharedDepName];
+
+          if (sharedDepVersion !== dependencyVersion) {
+            throw new Error(pkgName + ' should be using ' + sharedDepName + '@' + dependencyVersion + ' but was ' + sharedDepVersion);
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/publishing/dependency-check.js
+++ b/test/publishing/dependency-check.js
@@ -33,7 +33,7 @@ describe('Shared dependency', function () {
           var dependencyVersion = dependencies[sharedDepName];
 
           if (sharedDepVersion !== dependencyVersion) {
-            throw new Error(depPkgName + ' should be using ' + sharedDepName + '@' + dependencyVersion + ' but was ' + sharedDepVersion);
+            throw new Error(depPkg.name + ' should be using ' + sharedDepName + '@' + dependencyVersion + ' but was ' + sharedDepVersion);
           }
         });
       });

--- a/test/publishing/dependency-check.js
+++ b/test/publishing/dependency-check.js
@@ -1,28 +1,39 @@
 'use strict';
+var execSync = require('child_process').execSync;
 
 var dependencies = require('../../package.json').dependencies;
 var dependencyNames = Object.keys(dependencies);
-var packages = dependencyNames.filter(function (d) {
-  // Remove scoped packages
-  return d[0] !== '@';
+var dependencyPackages = dependencyNames.map(function (depName) {
+  var depPackages = {};
+  var depVersion = dependencies[depName];
+  var cmd = 'npm view --json ' + depName + '@' + depVersion + ' dependencies';
+  var result = execSync(cmd).toString();
+
+  if (result) {
+    depPackages = JSON.parse(result);
+  }
+
+  return {
+    name: depName,
+    dependencies: depPackages
+  };
 });
 
 describe('Shared dependency', function () {
-  packages.forEach(function (pkgName) {
-    describe(pkgName, function () {
-      var pkgDependencies = require('../../node_modules/' + pkgName + '/package.json').dependencies;
-      var sharedDependencyNames = Object.keys(pkgDependencies).filter(function (d) {
+  dependencyPackages.forEach(function (depPkg) {
+    describe(depPkg.name, function () {
+      var sharedDependencyNames = Object.keys(depPkg.dependencies).filter(function (d) {
         return dependencyNames.indexOf(d) !== -1;
       });
 
       sharedDependencyNames.forEach(function (sharedDepName) {
-        var sharedDepVersion = pkgDependencies[sharedDepName];
+        var sharedDepVersion = depPkg.dependencies[sharedDepName];
 
         it('uses ' + sharedDepName + '@' + sharedDepVersion, function () {
           var dependencyVersion = dependencies[sharedDepName];
 
           if (sharedDepVersion !== dependencyVersion) {
-            throw new Error(pkgName + ' should be using ' + sharedDepName + '@' + dependencyVersion + ' but was ' + sharedDepVersion);
+            throw new Error(depPkgName + ' should be using ' + sharedDepName + '@' + dependencyVersion + ' but was ' + sharedDepVersion);
           }
         });
       });


### PR DESCRIPTION
### Summary
We should always use the same shared dependency versions. This check will help us verify if our versions are off.

The publishing tests are separated from our normal tests because they are only useful before a release, and we may update dependency versions between releases.

### Checklist

- [ ] Added a changelog entry
- [X] Ran unit tests
