### PR TITLE
Run PayPal tests as separate build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ notifications:
 env:
   matrix:
   - TEST="test"
-  - TEST="test:integration" PLATFORM="desktop" IS_INTEGRATION_TEST=true
+  - TEST="test:integration:paypal-only" PLATFORM="desktop" IS_INTEGRATION_TEST=true
+  - TEST="test:integration:skip-paypal" PLATFORM="desktop" IS_INTEGRATION_TEST=true
   # iOS tests on Travis are flaky. Run these manually before merging something in
   # - TEST="test:integration" PLATFORM="ios" IS_INTEGRATION_TEST=true
   global:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "pretest": "npm run lint",
     "test": "karma start test/config/karma.js --single-run",
     "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
+    "test:integration:paypal-only": "RUN_PAYPAL_ONLY=true npm run test:integration",
+    "test:integration:skip-paypal": "SKIP_PAYPAL=true npm run test:integration",
     "test:publishing": "npm run pretest && mocha test/publishing",
     "deploy:gh-pages": "./scripts/deploy-gh-pages",
     "prepublish": "npm run test:publishing"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ Dotenv.load
 
 HOSTNAME = `hostname`.chomp
 PORT = ENV["PORT"] || 4567
+RUN_PAYPAL_ONLY = ENV["RUN_PAYPAL_ONLY"]
+SKIP_PAYPAL = ENV["SKIP_PAYPAL"]
 
 Capybara.default_driver = :selenium
 Capybara.app_host = "https://#{HOSTNAME}:#{PORT}"
@@ -75,5 +77,13 @@ RSpec.configure do |config|
 
   config.define_derived_metadata(:file_path => %r{/spec}) do |metadata|
     metadata[:sauce] = true
+  end
+
+  config.filter_run_excluding :paypal => true if SKIP_PAYPAL
+
+  if RUN_PAYPAL_ONLY
+    config.around do |example|
+      example.run if example.metadata[:paypal]
+    end
   end
 end


### PR DESCRIPTION
### Summary

Separates out PayPal tests from main build so we can more easily retry them when they fail for being flaky.

### Checklist

- [ ] ~~Added a changelog entry~~
- [ ] ~~Ran unit tests~~
