### PR TITLE
Add aria-label to payment options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Add `aria-label` attribute to payment options
+
 1.4.0
 ------
 - Add `paymentOptionSelected` event

--- a/src/html/payment-option.html
+++ b/src/html/payment-option.html
@@ -4,7 +4,7 @@
   </svg>
 </div>
 
-<div class="braintree-option__label">
+<div class="braintree-option__label" aria-label="@OPTION_LABEL">
   @OPTION_TITLE
   <div class="braintree-option__disabled-message"></div>
 </div>

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -28,6 +28,7 @@ PaymentOptionsView.prototype._initialize = function () {
 };
 
 PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
+  var paymentSource;
   var div = document.createElement('div');
   var html = paymentMethodOptionHTML;
   var clickHandler = function clickHandler() {
@@ -41,18 +42,24 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
 
   switch (paymentOptionID) {
     case paymentOptionIDs.card:
+      paymentSource = this.strings.Card;
       html = html.replace(/@ICON/g, 'iconCardFront');
-      html = html.replace(/@OPTION_TITLE/g, this.strings.Card);
+      html = html.replace(/@OPTION_LABEL/g, this._generateOptionLabel(paymentSource));
+      html = html.replace(/@OPTION_TITLE/g, paymentSource);
       html = html.replace(/@CLASSNAME/g, 'braintree-icon--bordered');
       break;
     case paymentOptionIDs.paypal:
+      paymentSource = this.strings.PayPal;
       html = html.replace(/@ICON/g, 'logoPayPal');
+      html = html.replace(/@OPTION_LABEL/g, this._generateOptionLabel(this.strings.PayPal));
       html = html.replace(/@OPTION_TITLE/g, this.strings.PayPal);
       html = html.replace(/@CLASSNAME/g, '');
       break;
     case paymentOptionIDs.paypalCredit:
+      paymentSource = this.strings['PayPal Credit'];
       html = html.replace(/@ICON/g, 'logoPayPalCredit');
-      html = html.replace(/@OPTION_TITLE/g, this.strings['PayPal Credit']);
+      html = html.replace(/@OPTION_LABEL/g, this._generateOptionLabel(paymentSource));
+      html = html.replace(/@OPTION_TITLE/g, paymentSource);
       html = html.replace(/@CLASSNAME/g, '');
       break;
     default:
@@ -68,6 +75,10 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
     div: div,
     clickHandler: clickHandler
   };
+};
+
+PaymentOptionsView.prototype._generateOptionLabel = function (paymentSourceString) {
+  return this.strings.payingWith.replace('{{paymentSource}}', paymentSourceString);
 };
 
 module.exports = PaymentOptionsView;

--- a/test/unit/views/payment-options-view.js
+++ b/test/unit/views/payment-options-view.js
@@ -15,16 +15,19 @@ var paymentOptionAttributes = {
   card: {
     className: 'braintree-icon--bordered',
     icon: '#iconCardFront',
+    optionLabel: 'Paying with Card',
     optionTitle: strings.Card,
     paymentOptionID: 'card'
   },
   paypal: {
     icon: '#logoPayPal',
+    optionLabel: 'Paying with PayPal',
     optionTitle: strings.PayPal,
     paymentOptionID: 'paypal'
   },
   paypalCredit: {
     icon: '#logoPayPalCredit',
+    optionLabel: 'Paying with PayPal Credit',
     optionTitle: strings['PayPal Credit'],
     paymentOptionID: 'paypalCredit'
   }
@@ -79,6 +82,7 @@ describe('PaymentOptionsView', function () {
         var iconContainer = icon.parentElement;
         var optionElement = paymentOptionsView.elements[option.paymentOptionID];
 
+        expect(label.getAttribute('aria-label')).to.equal(option.optionLabel);
         expect(label.innerHTML).to.contain(option.optionTitle);
         expect(icon.href.baseVal).to.equal(option.icon);
         expect(optionElement.div).to.exist;


### PR DESCRIPTION
### Summary

Adds `aria-label` attribute to payment options so it reads "Paying with ..." when tabbed over or selected. We pull the label from the strings, so it is localized.

### Checklist

- [x] Added a changelog entry
