### PR TITLE
Dynamically add sauce tag based on build

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,18 @@ def download_sauce_connect
   puts "[DOWNLOADED] Sauce connect"
 end
 
+def should_run_on_sauce(metadata)
+  if RUN_PAYPAL_ONLY
+    return metadata.include?(:paypal)
+  end
+
+  if SKIP_PAYPAL
+    return metadata.include?(:paypal) == false
+  end
+
+  return true
+end
+
 def wait_port(port)
   loop do
     `lsof -i :#{port}`
@@ -76,14 +88,6 @@ RSpec.configure do |config|
   end
 
   config.define_derived_metadata(:file_path => %r{/spec}) do |metadata|
-    metadata[:sauce] = true
-  end
-
-  config.filter_run_excluding :paypal => true if SKIP_PAYPAL
-
-  if RUN_PAYPAL_ONLY
-    config.around do |example|
-      example.run if example.metadata[:paypal]
-    end
+    metadata[:sauce] = true if should_run_on_sauce(metadata)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,13 +36,7 @@ def download_sauce_connect
 end
 
 def should_run_on_sauce(metadata)
-  if RUN_PAYPAL_ONLY
-    return metadata.include?(:paypal)
-  end
-
-  if SKIP_PAYPAL
-    return metadata.include?(:paypal) == false
-  end
+  return metadata.include?(:paypal) if RUN_PAYPAL_ONLY
 
   return true
 end
@@ -90,4 +84,6 @@ RSpec.configure do |config|
   config.define_derived_metadata(:file_path => %r{/spec}) do |metadata|
     metadata[:sauce] = true if should_run_on_sauce(metadata)
   end
+
+  config.filter_run_excluding :paypal => true if SKIP_PAYPAL
 end


### PR DESCRIPTION
### Summary

Dynamically adds the sauce metadata tag depending on the current build. If the sauce metadata tag is missing, sauce ignores the test.

### Checklist

- [ ] Added a changelog entry
