### PR TITLE
Move publishing test to separate travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ notifications:
 env:
   matrix:
   - TEST="test"
+  - TEST="test:publishing"
   - TEST="test:integration:paypal-only" PLATFORM="desktop" IS_INTEGRATION_TEST=true
   - TEST="test:integration:paypal-skipped" PLATFORM="desktop" IS_INTEGRATION_TEST=true
   # iOS tests on Travis are flaky. Run these manually before merging something in

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "test:integration": ". ./.env && bundle exec rake sauce:spec test_files=spec",
     "test:integration:paypal-only": "RUN_PAYPAL_ONLY=true npm run test:integration",
     "test:integration:paypal-skipped": "SKIP_PAYPAL=true npm run test:integration",
-    "test:publishing": "npm run pretest && mocha test/publishing",
-    "deploy:gh-pages": "./scripts/deploy-gh-pages",
-    "prepublish": "npm run test:publishing"
+    "test:publishing": "mocha test/publishing",
+    "deploy:gh-pages": "./scripts/deploy-gh-pages"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary

NPM has some weird behavior with `prepublish` scripts in that they run whenever you `npm install`. So this test is actually being run before each build (along with linting). 

This PR moves it to a separate build on Travis.

### Checklist

- [ ] ~~Added a changelog entry~~
