### PR TITLE
Clear active payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ unreleased
 - Update browser-detection to v1.5.0
 - Add `aria-label` attribute to payment options
 - Update checkout.js to v4.0.95
-- Add `clearActivePaymentMethod` to remove selected payment method
+- Add `clearSelectedPaymentMethod` to remove selected payment method
 
 1.4.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ unreleased
 - Update browser-detection to v1.5.0
 - Add `aria-label` attribute to payment options
 - Update checkout.js to v4.0.95
+- Add `clearActivePaymentMethod` to remove selected payment method
 
 1.4.0
 ------

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -155,6 +155,41 @@ describe "Drop-in" do
     end
   end
 
+  describe "clearActivePaymentMethod" do
+    it "clears active payment method card" do
+      visit_dropin_url
+
+      click_option("card")
+      hosted_field_send_input("number", "4111111111111111")
+      hosted_field_send_input("expirationDate", "1019")
+      hosted_field_send_input("cvv", "123")
+
+      submit_pay
+
+      expect(page).to have_selector(".braintree-method.braintree-method--active")
+
+      find("#clear-button").click
+
+      expect(page).to_not have_selector(".braintree-method.braintree-method--active")
+    end
+
+    it "clears active payment method card", :paypal do
+      visit_dropin_url
+
+      click_option("paypal")
+
+      open_popup_and_complete_login
+
+      submit_pay
+
+      expect(page).to have_selector(".braintree-method.braintree-method--active")
+
+      find("#clear-button").click
+
+      expect(page).to_not have_selector(".braintree-method.braintree-method--active")
+    end
+  end
+
   describe "events" do
     it "disable and enable submit button on credit card validity" do
       visit_dropin_url

--- a/spec/braintree_web_drop_in_spec.rb
+++ b/spec/braintree_web_drop_in_spec.rb
@@ -155,7 +155,7 @@ describe "Drop-in" do
     end
   end
 
-  describe "clearActivePaymentMethod" do
+  describe "clearSelectedPaymentMethod" do
     it "clears active payment method card" do
       visit_dropin_url
 

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -59,6 +59,14 @@ DropinModel.prototype.changeActivePaymentView = function (paymentViewID) {
   this._emit('changeActivePaymentView', paymentViewID);
 };
 
+DropinModel.prototype.removeActivePaymentMethodView = function () {
+  this._activePaymentMethod = null;
+  this._emit('removeActivePaymentMethod');
+  this.setPaymentMethodRequestable({
+    isRequestable: false
+  });
+};
+
 DropinModel.prototype.selectPaymentOption = function (paymentViewID) {
   this._emit('paymentOptionSelected', {
     paymentOption: paymentViewID

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -59,7 +59,7 @@ DropinModel.prototype.changeActivePaymentView = function (paymentViewID) {
   this._emit('changeActivePaymentView', paymentViewID);
 };
 
-DropinModel.prototype.removeActivePaymentMethodView = function () {
+DropinModel.prototype.removeActivePaymentMethod = function () {
   this._activePaymentMethod = null;
   this._emit('removeActivePaymentMethod');
   this.setPaymentMethodRequestable({

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -354,7 +354,7 @@ Dropin.prototype.clearActivePaymentMethod = function () {
 
   this._navigateToInitialView();
 
-  this._model.removeActivePaymentMethodView();
+  this._model.removeActivePaymentMethod();
 };
 
 Dropin.prototype._removeUnvaultedPaymentMethods = function (filter) {

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -326,7 +326,7 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
 };
 
 /**
- * Removes the currently selected payment method and returns the customer to the payment options view.
+ * Removes the currently selected payment method and returns the customer to the payment options view. Does not remove vaulted payment methods.
  * @public
  * @returns {void}
  * @example
@@ -341,7 +341,7 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
  *       // transaction sale with selected payment method failed
  *       // clear the selected payment method and add a message
  *       // to the checkout page about the failure
- *       dropinInstance.clearActivePaymentMethod();
+ *       dropinInstance.clearSelectedPaymentMethod();
  *       divForErrorMessages.textContent = 'my error message about entering a different payment method.';
  *     } else {
  *       // redirect to success page
@@ -349,7 +349,7 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
  *   });
  * });
  */
-Dropin.prototype.clearActivePaymentMethod = function () {
+Dropin.prototype.clearSelectedPaymentMethod = function () {
   this._removeUnvaultedPaymentMethods();
 
   this._navigateToInitialView();

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -773,6 +773,10 @@ $loader-scale-duration: 300ms;
   visibility: visible;
 }
 
+.braintree-show-methods [data-braintree-id='methods-label'].braintree-no-payment-method-selected {
+  transform: translateY(30px);
+}
+
 .braintree-show-methods.braintree-show-options [data-braintree-id='choose-a-way-to-pay'] {
   transform: translateY(30px);
   visibility: hidden;

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -109,7 +109,7 @@ MainView.prototype._initialize = function () {
   this.model.on('removeActivePaymentMethod', function () {
     var activePaymentView = this.getView(this.model.getActivePaymentView());
 
-    if (activePaymentView) {
+    if (activePaymentView && typeof activePaymentView.removeActivePaymentMethod === 'function') {
       activePaymentView.removeActivePaymentMethod();
     }
   }.bind(this));

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -106,6 +106,14 @@ MainView.prototype._initialize = function () {
     activePaymentView.onSelection();
   }.bind(this));
 
+  this.model.on('removeActivePaymentMethod', function () {
+    var activePaymentView = this.getView(this.model.getActivePaymentView());
+
+    if (activePaymentView) {
+      activePaymentView.removeActivePaymentMethod();
+    }
+  }.bind(this));
+
   if (hasMultiplePaymentOptions) {
     paymentOptionsView = new PaymentOptionsView({
       client: this.client,

--- a/src/views/payment-methods-view.js
+++ b/src/views/payment-methods-view.js
@@ -2,6 +2,9 @@
 
 var BaseView = require('./base-view');
 var PaymentMethodView = require('./payment-method-view');
+var DropinError = require('../lib/dropin-error');
+var classlist = require('../lib/classlist');
+var errors = require('../constants').errors;
 var Promise = require('../lib/promise');
 
 var PAYMENT_METHOD_TYPE_TO_TRANSLATION_STRING = {
@@ -34,6 +37,15 @@ PaymentMethodsView.prototype._initialize = function () {
   for (i = paymentMethods.length - 1; i >= 0; i--) {
     this._addPaymentMethod(paymentMethods[i]);
   }
+};
+
+PaymentMethodsView.prototype.removeActivePaymentMethod = function () {
+  if (!this.activeMethodView) {
+    return;
+  }
+  this.activeMethodView.setActive(false);
+  this.activeMethodView = null;
+  classlist.add(this._headingLabel, 'braintree-no-payment-method-selected');
 };
 
 PaymentMethodsView.prototype._getPaymentMethodString = function () {
@@ -93,9 +105,13 @@ PaymentMethodsView.prototype._changeActivePaymentMethodView = function (paymentM
     previousActiveMethodView.setActive(false);
   }
   this.activeMethodView.setActive(true);
+  classlist.remove(this._headingLabel, 'braintree-no-payment-method-selected');
 };
 
 PaymentMethodsView.prototype.requestPaymentMethod = function () {
+  if (!this.activeMethodView) {
+    return Promise.reject(new DropinError(errors.NO_PAYMENT_METHOD_ERROR));
+  }
   return Promise.resolve(this.activeMethodView.paymentMethod);
 };
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -252,7 +252,7 @@
   }, false);
 
   clearButton.addEventListener('click', function () {
-    dropinInstance.clearActivePaymentMethod();
+    dropinInstance.clearSelectedPaymentMethod();
     clearButton.className = 'hidden';
   });
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -74,6 +74,7 @@
   <input id="pay-button" type="submit" value="Pay" disabled>
   <button id="create-button" disabled type="button">Create</button>
   <button id="teardown-button" type="button">Teardown</button>
+  <button class="hidden" id="clear-button" type="button">Clear Payment Method</button>
 </form>
 
 <div id="update-paypal-configuration" class="hidden">
@@ -125,6 +126,7 @@
   var payButton = document.querySelector('#pay-button');
   var createButton = document.querySelector('#create-button');
   var teardownButton = document.querySelector('#teardown-button');
+  var clearButton = document.querySelector('#clear-button');
 
   function getDropinConfig () {
     var query = window.location.search.substring(1);
@@ -181,15 +183,20 @@
 
       if (!config.disablePaymentMethodRequestableListeners) {
         if (instance.isPaymentMethodRequestable()) {
+          clearButton.className = '';
           payButton.removeAttribute('disabled');
         }
 
         instance.on('paymentMethodRequestable', function (event) {
+          if (event.paymentMethodIsSelected) {
+            clearButton.className = '';
+          }
           payButton.removeAttribute('disabled');
           console.log('paymentMethodRequestable', event);
         });
 
         instance.on('noPaymentMethodRequestable', function (event) {
+          clearButton.className = 'hidden';
           payButton.setAttribute('disabled', true);
           console.log('noPaymentMethodRequestable');
         });
@@ -233,16 +240,24 @@
 
     dropinInstance.requestPaymentMethod(function (err, payload) {
       if (err) {
+        clearButton.className = 'hidden';
         error.textContent = err.message;
         results.textContent = '';
       } else {
+        clearButton.className = '';
         results.textContent = JSON.stringify(payload, null, 2);
         error.textContent = '';
       }
     });
   }, false);
 
+  clearButton.addEventListener('click', function () {
+    dropinInstance.clearActivePaymentMethod();
+    clearButton.className = 'hidden';
+  });
+
   teardownButton.addEventListener('click', function () {
+    clearButton.className = 'hidden';
     teardownButton.setAttribute('disabled', true);
     dropinInstance.teardown(function (err) {
       if (err) {

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -318,6 +318,38 @@ describe('DropinModel', function () {
     });
   });
 
+  describe('removeActivePaymentMethod', function () {
+    beforeEach(function () {
+      this.model = new DropinModel(this.modelOptions);
+      this.sandbox.stub(this.model, '_emit');
+      this.sandbox.stub(this.model, 'setPaymentMethodRequestable');
+    });
+
+    it('sets active payment method to null', function () {
+      this.model._activePaymentMethod = {foo: 'bar'};
+
+      this.model.removeActivePaymentMethod();
+
+      expect(this.model._activePaymentMethod).to.not.exist;
+    });
+
+    it('emits removeActivePaymentMethod event', function () {
+      this.model.removeActivePaymentMethod();
+
+      expect(this.model._emit).to.be.calledOnce;
+      expect(this.model._emit).to.be.calledWith('removeActivePaymentMethod');
+    });
+
+    it('sets payment method to not be requestable', function () {
+      this.model.removeActivePaymentMethod();
+
+      expect(this.model.setPaymentMethodRequestable).to.be.calledOnce;
+      expect(this.model.setPaymentMethodRequestable).to.be.calledWith({
+        isRequestable: false
+      });
+    });
+  });
+
   describe('getActivePaymentMethod', function () {
     it('returns _activePaymentMethod', function () {
       var model = new DropinModel(this.modelOptions);

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1024,6 +1024,7 @@ describe('Dropin', function () {
           {nonce: '4', type: 'PayPalAccount'},
           {nonce: '5', type: 'PayPalAccount', vaulted: true}
         ]),
+        removeActivePaymentMethod: this.sandbox.stub(),
         removePaymentMethod: this.sandbox.stub()
       };
 
@@ -1057,6 +1058,7 @@ describe('Dropin', function () {
           {nonce: '2', type: 'CreditCard', vaulted: true},
           {nonce: '3', type: 'PayPalAccount', vaulted: true}
         ]),
+        removeActivePaymentMethod: this.sandbox.stub(),
         removePaymentMethod: this.sandbox.stub()
       };
 
@@ -1085,6 +1087,7 @@ describe('Dropin', function () {
       };
       instance._model = {
         getPaymentMethods: this.sandbox.stub().returns([]),
+        removeActivePaymentMethod: this.sandbox.stub(),
         supportedPaymentOptions: ['paypal', 'card'],
         removePaymentMethod: this.sandbox.stub()
       };
@@ -1115,6 +1118,7 @@ describe('Dropin', function () {
       };
       instance._model = {
         getPaymentMethods: this.sandbox.stub().returns([]),
+        removeActivePaymentMethod: this.sandbox.stub(),
         supportedPaymentOptions: ['paypal'],
         removePaymentMethod: this.sandbox.stub()
       };
@@ -1145,6 +1149,7 @@ describe('Dropin', function () {
       };
       instance._model = {
         getPaymentMethods: this.sandbox.stub().returns([]),
+        removeActivePaymentMethod: this.sandbox.stub(),
         removePaymentMethod: this.sandbox.stub()
       };
 
@@ -1175,6 +1180,7 @@ describe('Dropin', function () {
         getPaymentMethods: this.sandbox.stub().returns([
           {nonce: '1', type: 'CreditCard'}
         ]),
+        removeActivePaymentMethod: this.sandbox.stub(),
         removePaymentMethod: this.sandbox.stub()
       };
 
@@ -1183,6 +1189,37 @@ describe('Dropin', function () {
       instance.clearActivePaymentMethod();
 
       expect(instance._mainView.setPrimaryView).to.not.be.called;
+    });
+
+    it('removes active payment method view', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'methods'
+        },
+        setPrimaryView: this.sandbox.stub()
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([
+          {nonce: '1', type: 'CreditCard'}
+        ]),
+        removeActivePaymentMethod: this.sandbox.stub(),
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._model.removeActivePaymentMethod).to.be.calledOnce;
     });
   });
 

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1000,7 +1000,7 @@ describe('Dropin', function () {
     });
   });
 
-  describe('clearActivePaymentMethod', function () {
+  describe('clearSelectedPaymentMethod', function () {
     it('removes saved payment methods if they are not vaulted', function () {
       var instance = new Dropin(this.dropinOptions);
       var getViewStub = this.sandbox.stub();
@@ -1030,7 +1030,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._model.removePaymentMethod).to.be.calledTwice;
       expect(instance._model.removePaymentMethod).to.be.calledWith({nonce: '3', type: 'CreditCard'});
@@ -1064,7 +1064,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._model.removePaymentMethod).to.not.be.called;
     });
@@ -1094,7 +1094,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._mainView.setPrimaryView).to.be.calledOnce;
       expect(instance._mainView.setPrimaryView).to.be.calledWith('options');
@@ -1125,7 +1125,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._mainView.setPrimaryView).to.be.calledOnce;
       expect(instance._mainView.setPrimaryView).to.be.calledWith('paypal');
@@ -1155,7 +1155,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._mainView.setPrimaryView).to.not.be.called;
     });
@@ -1186,7 +1186,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._mainView.setPrimaryView).to.not.be.called;
     });
@@ -1217,7 +1217,7 @@ describe('Dropin', function () {
 
       getViewStub.withArgs('methods').returns(fakeMethodsView);
 
-      instance.clearActivePaymentMethod();
+      instance.clearSelectedPaymentMethod();
 
       expect(instance._model.removeActivePaymentMethod).to.be.calledOnce;
     });

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1000,6 +1000,192 @@ describe('Dropin', function () {
     });
   });
 
+  describe('clearActivePaymentMethod', function () {
+    it('removes saved payment methods if they are not vaulted', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'view'
+        }
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([
+          {nonce: '1', type: 'PayPalAccount', vaulted: true},
+          {nonce: '2', type: 'CreditCard', vaulted: true},
+          {nonce: '3', type: 'CreditCard'},
+          {nonce: '4', type: 'PayPalAccount'},
+          {nonce: '5', type: 'PayPalAccount', vaulted: true}
+        ]),
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._model.removePaymentMethod).to.be.calledTwice;
+      expect(instance._model.removePaymentMethod).to.be.calledWith({nonce: '3', type: 'CreditCard'});
+      expect(instance._model.removePaymentMethod).to.be.calledWith({nonce: '4', type: 'PayPalAccount'});
+    });
+
+    it('does not call removePaymentMethod if no non-vaulted paypal accounts are avaialble', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'view'
+        }
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([
+          {nonce: '1', type: 'PayPalAccount', vaulted: true},
+          {nonce: '2', type: 'CreditCard', vaulted: true},
+          {nonce: '3', type: 'PayPalAccount', vaulted: true}
+        ]),
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._model.removePaymentMethod).to.not.be.called;
+    });
+
+    it('sets primary view to options if on the methods view and there are no saved payment methods and supportedPaymentOptions is greater than 1', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'methods'
+        },
+        setPrimaryView: this.sandbox.stub()
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([]),
+        supportedPaymentOptions: ['paypal', 'card'],
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._mainView.setPrimaryView).to.be.calledOnce;
+      expect(instance._mainView.setPrimaryView).to.be.calledWith('options');
+    });
+
+    it('sets primary view to available payment option view if on the methods view and there are not saved payment methods and only one payment option is available', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'methods'
+        },
+        setPrimaryView: this.sandbox.stub()
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([]),
+        supportedPaymentOptions: ['paypal'],
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._mainView.setPrimaryView).to.be.calledOnce;
+      expect(instance._mainView.setPrimaryView).to.be.calledWith('paypal');
+    });
+
+    it('does not set primary view if current primary view is not methods', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'any-id-but-methods'
+        },
+        setPrimaryView: this.sandbox.stub()
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([]),
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._mainView.setPrimaryView).to.not.be.called;
+    });
+
+    it('does not set primary view if there are saved payment methods', function () {
+      var instance = new Dropin(this.dropinOptions);
+      var getViewStub = this.sandbox.stub();
+      var fakeMethodsView = {
+        getPaymentMethod: this.sandbox.stub().returns({
+          type: 'PayPalAccount'
+        })
+      };
+
+      instance._mainView = {
+        getView: getViewStub,
+        primaryView: {
+          ID: 'methods'
+        },
+        setPrimaryView: this.sandbox.stub()
+      };
+      instance._model = {
+        getPaymentMethods: this.sandbox.stub().returns([
+          {nonce: '1', type: 'CreditCard'}
+        ]),
+        removePaymentMethod: this.sandbox.stub()
+      };
+
+      getViewStub.withArgs('methods').returns(fakeMethodsView);
+
+      instance.clearActivePaymentMethod();
+
+      expect(instance._mainView.setPrimaryView).to.not.be.called;
+    });
+  });
+
   describe('payment method requestable events', function () {
     it('emits paymentMethodRequestable event when the model emits paymentMethodRequestable', function (done) {
       var instance = new Dropin(this.dropinOptions);

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -593,6 +593,22 @@ describe('MainView', function () {
       });
     });
 
+    describe('for removeActivePaymentMethod', function () {
+      it('calls removeActivePaymentMethod if there is an active view', function (done) {
+        var optionsView = {ID: 'options', removeActivePaymentMethod: this.sandbox.stub()};
+
+        this.mainView.addView(optionsView);
+
+        this.sandbox.stub(this.model, 'getActivePaymentView').returns('options');
+        this.model._emit('removeActivePaymentMethod');
+
+        setTimeout(function () {
+          expect(optionsView.removeActivePaymentMethod).to.be.calledOnce;
+          done();
+        }, CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT);
+      });
+    });
+
     describe('for changeActivePaymentView', function () {
       beforeEach(function () {
         this.sandbox.stub(this.model, 'setPaymentMethodRequestable');

--- a/test/unit/views/payment-methods-view.js
+++ b/test/unit/views/payment-methods-view.js
@@ -3,6 +3,7 @@
 var BaseView = require('../../../src/views/base-view');
 var PaymentMethodsView = require('../../../src/views/payment-methods-view');
 var DropinModel = require('../../../src/dropin-model');
+var classlist = require('../../../src/lib/classlist');
 var fake = require('../../helpers/fake');
 var fs = require('fs');
 var strings = require('../../../src/translations/en_US');
@@ -271,6 +272,51 @@ describe('PaymentMethodsView', function () {
 
       expect(paymentMethodsViews.views.length).to.equal(1);
       expect(methodsContainer.childElementCount).to.equal(1);
+    });
+  });
+
+  describe('removeActivePaymentMethod', function () {
+    beforeEach(function () {
+      var model;
+      var modelOptions = fake.modelOptions();
+
+      modelOptions.merchantConfiguration.authorization = fake.clientToken;
+      model = new DropinModel(modelOptions);
+
+      this.paymentMethodsViews = new PaymentMethodsView({
+        element: this.element,
+        model: model,
+        merchantConfiguration: {
+          authorization: fake.clientToken
+        },
+        strings: strings
+      });
+      this.activeMethodView = {
+        setActive: this.sandbox.stub()
+      };
+
+      this.paymentMethodsViews.activeMethodView = this.activeMethodView;
+      this.sandbox.stub(classlist, 'add');
+    });
+
+    it('sets the active method view to not active', function () {
+      this.paymentMethodsViews.removeActivePaymentMethod();
+
+      expect(this.activeMethodView.setActive).to.be.calledOnce;
+      expect(this.activeMethodView.setActive).to.be.calledWith(false);
+    });
+
+    it('removes active method view from instance', function () {
+      this.paymentMethodsViews.removeActivePaymentMethod();
+
+      expect(this.paymentMethodsViews.activeMethodView).to.not.exist;
+    });
+
+    it('applies class to heading label to hide it when no payment methods are selected', function () {
+      this.paymentMethodsViews.removeActivePaymentMethod();
+
+      expect(classlist.add).to.be.calledOnce;
+      expect(classlist.add).to.be.calledWith(this.sandbox.match.any, 'braintree-no-payment-method-selected');
     });
   });
 


### PR DESCRIPTION
### Summary

Adds a `clearActivePaymentMethod` method which removes the selected payment method when called.

The use case is that there are some cases where the saved nonce can be consumed, but drop-in has no idea that it is consumed and shows a UI to the customer that the nonce can be submitted.

For instance, if you have a single page app and you send the nonce to your server and the transaction fails, you can update your ui to instruct the customer to try another payment method, but drop-in is stuck showing the ✅ .

This method removes that when called.

Another use case will be for 3DS, which consumes the nonce. IE, if liability does not shift, the merchant may want the customer to try a different payment method.

If this method is called on the vaulted payment method view, it leaves the vaulted payment methods present, but removes the ✅  from the selected one (and hides the `Paying with <TYPE>` message.

### Checklist

- [x] Added a changelog entry
