### PR TITLE
Update braintre-web to v3.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Use version 3.20.1 of braintree-web
-- Update browser-detection to v1.5.0
+- Update browser-detection to v1.6.0
 - Add `aria-label` attribute to payment options
 - Update checkout.js to v4.0.95
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 unreleased
 ----------
-- Use version 3.20.0 of braintree-web
+- Use version 3.20.1 of braintree-web
 - Update browser-detection to v1.5.0
 - Add `aria-label` attribute to payment options
 - Update checkout.js to v4.0.95

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "braintree-web": "3.20.1",
-    "@braintree/browser-detection": "1.5.0",
+    "@braintree/browser-detection": "1.6.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.20.0",
+    "braintree-web": "3.20.1",
     "@braintree/browser-detection": "1.5.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary
Updates braintree-web to v3.20.1

I expect the publishing build to fail (just want to do a sanity check that it is). Will update browser detection when it does.

### Checklist

- [x] Added a changelog entry
