### PR TITLE
Use jsdoc-template 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-util": "3.0.7",
     "is-uuid": "1.0.2",
     "jsdoc": "3.4.0",
-    "jsdoc-template": "braintree/jsdoc-template#3.0.0",
+    "jsdoc-template": "braintree/jsdoc-template#3.1.0",
     "karma": "0.13.22",
     "karma-browserify": "5.0.5",
     "karma-mocha": "1.1.1",


### PR DESCRIPTION
### Summary

Includes anchor tags on examples and wider max-width for tables