### PR TITLE
Include data collector in teardown

### DIFF
--- a/spec/data_collector_spec.rb
+++ b/spec/data_collector_spec.rb
@@ -4,7 +4,8 @@ describe "Drop-in with Data Collector" do
   include DropIn
 
   it "includes device data in request payment method payload" do
-    visit_dropin_url
+    options = '{"paypal":true}'
+    visit_dropin_url("?dataCollector=#{options}")
 
     click_option("card")
     hosted_field_send_input("number", "4111111111111111")

--- a/spec/data_collector_spec.rb
+++ b/spec/data_collector_spec.rb
@@ -1,0 +1,18 @@
+require_relative "helpers/drop_in_helper"
+
+describe "Drop-in with Data Collector" do
+  include DropIn
+
+  it "includes device data in request payment method payload" do
+    visit_dropin_url
+
+    click_option("card")
+    hosted_field_send_input("number", "4111111111111111")
+    hosted_field_send_input("expirationDate", "1019")
+    hosted_field_send_input("cvv", "123")
+
+    submit_pay
+
+    expect(page).to have_content('"deviceData": "{\"correlation_id\"')
+  end
+end

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -40,6 +40,7 @@ var VERSION = process.env.npm_package_version;
  * @property {string} details.lastTwo Last two digits of card number.
  * @property {string} description A human-readable description.
  * @property {string} type The payment method type, always `CreditCard` when the method requested is a card.
+ * @property {?string} deviceData If data collector is configured, the device data property to be used when making a transaction.
  */
 
 /**
@@ -47,6 +48,7 @@ var VERSION = process.env.npm_package_version;
  * @property {string} nonce The payment method nonce, used by your server to charge the PayPal account.
  * @property {object} details Additional PayPal account details. See a full list of details in the [PayPal client reference](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/PayPalCheckout.html#~tokenizePayload).
  * @property {string} type The payment method type, always `PayPalAccount` when the method requested is a PayPal account.
+ * @property {?string} deviceData If data collector is configured, the device data property to be used when making a transaction.
  */
 
 /**
@@ -462,6 +464,40 @@ Dropin.prototype._disableErroredPaymentMethods = function () {
  * @public
  * @param {callback} [callback] The first argument will be an error if no payment method is available and will otherwise be null. The second argument will be an object containing a payment method nonce; either a {@link Dropin~cardPaymentMethodPayload|cardPaymentMethodPayload} or a {@link Dropin~paypalPaymentMethodPayload|paypalPaymentMethodPayload}. If no callback is provided, `requestPaymentMethod` will return a promise.
  * @returns {void|Promise} Returns a promise if no callback is provided.
+ * @example <caption>Requesting a payment method</caption>
+ * var form = document.querySelector('#my-form');
+ * var hiddenNonceInput = document.querySelector('#my-nonce-input');
+ *
+ * form.addEventListener('submit', function (event) {
+ *  event.preventDefault();
+ *
+ *  dropinInstance.requestPaymentMethod(function (err, payload) {
+ *    if (err) {
+ *      // handle error
+ *      return;
+ *    }
+ *    hiddenNonceInput.value = payload.nonce;
+ *    form.submit();
+ *  });
+ * });
+ * @example <caption>Requesting a payment method with data collector</caption>
+ * var form = document.querySelector('#my-form');
+ * var hiddenNonceInput = document.querySelector('#my-nonce-input');
+ * var hiddenDeviceDataInput = document.querySelector('#my-device-data-input');
+ *
+ * form.addEventListener('submit', function (event) {
+ *  event.preventDefault();
+ *
+ *  dropinInstance.requestPaymentMethod(function (err, payload) {
+ *    if (err) {
+ *      // handle error
+ *      return;
+ *    }
+ *    hiddenNonceInput.value = payload.nonce;
+ *    hiddenDeviceDataInput.value = payload.deviceData;
+ *    form.submit();
+ *  });
+ * });
  */
 Dropin.prototype.requestPaymentMethod = function () {
   return this._mainView.requestPaymentMethod().then(function (payload) {

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ var VERSION = process.env.npm_package_version;
  */
 
 /**
- * @typedef {object} dataCollectorOptions The configuration options for Data Collector. Requires [advanced fraud protection](https://developers.braintreepayments.com/guides/advanced-fraud-tools/client-side/javascript/v3) to be enabled in the Braintree gateway. Contact our [support team](https://developers.braintreepayments.com/forms/contact) to configure your Kount ID.
+ * @typedef {object} dataCollectorOptions The configuration options for Data Collector. Requires [advanced fraud protection](https://developers.braintreepayments.com/guides/advanced-fraud-tools/client-side/javascript/v3) to be enabled in the Braintree gateway. Contact our [support team](https://developers.braintreepayments.com/forms/contact) to configure your Kount ID. The device data will be included on the {@link Dropin#requestPaymentMethod|requestPaymentMethod payload}.
  *
  * @param {boolean} [kount] If true, Kount fraud data collection is enabled. Required if `paypal` parameter is not used.
  * @param {boolean} [paypal] If true, PayPal fraud data collection is enabled. Required if `kount` parameter is not used.

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -774,6 +774,30 @@ describe('Dropin', function () {
       }.bind(this));
     });
 
+    it('calls teardown on dataCollector', function (done) {
+      this.instance._dataCollectorInstance = {
+        teardown: this.sandbox.stub().resolves()
+      };
+
+      this.instance.teardown(function () {
+        expect(this.instance._dataCollectorInstance.teardown).to.be.calledOnce;
+        done();
+      }.bind(this));
+    });
+
+    it('passes errors from data collector teardown to callback', function (done) {
+      var error = new Error('Data Collector failured');
+
+      this.instance._dataCollectorInstance = {
+        teardown: this.sandbox.stub().rejects(error)
+      };
+
+      this.instance.teardown(function (err) {
+        expect(err.message).to.equal('Drop-in errored tearing down Data Collector.');
+        done();
+      });
+    });
+
     it('passes errors in mainView teardown to callback', function (done) {
       var error = new Error('Teardown Error');
 


### PR DESCRIPTION
### Summary

Calls `dataCollectorInstance.teardown` when tearing down the rest of drop-in.

### Checklist

- [ ] ~~Added a changelog entry~~
