### PR TITLE
Update PayPal Checkout.js to v4.0.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Add data collector
+- Update PayPal Checkout to v4.0.110
 
 1.6.1
 ------

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,7 +42,7 @@ module.exports = {
   ANALYTICS_REQUEST_TIMEOUT_MS: 2000,
   ANALYTICS_PREFIX: 'web.dropin.',
   CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT: 200,
-  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.4.0.95.min.js',
+  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.4.0.110.min.js',
   INTEGRATION: 'dropin2',
   PAYPAL_CHECKOUT_SCRIPT_ID: 'braintree-dropin-paypal-checkout-script',
   STYLESHEET_ID: 'braintree-dropin-stylesheet'


### PR DESCRIPTION
closes #259

### Summary

There's a bug in the version of checkout.js we are using that prevents the customer from logging out. Update the version and it is fixed.

### Checklist

- [x] Added a changelog entry
