### PR TITLE
Update braintree-web to v3.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Add data collector
 - Update PayPal Checkout to v4.0.110
+- Update braintree-web to v3.22.1
 
 1.6.1
 ------

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.22.0",
+    "braintree-web": "3.22.1",
     "@braintree/browser-detection": "1.6.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary

Updates braintree-web to version 3.22.1

### Checklist

- [x] Added a changelog entry
