### PR TITLE
Refactor view initialization

### DIFF
--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -62,6 +62,7 @@ MainView.prototype._initialize = function () {
         client: this.client,
         strings: this.strings
       });
+      paymentSheetView.initialize();
 
       this.addView(paymentSheetView);
       ids.push(paymentSheetView.ID);

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -14,8 +14,9 @@ function BasePayPalView() {
 
 BasePayPalView.prototype = Object.create(BaseView.prototype);
 
-BasePayPalView.prototype._initialize = function (isCredit) {
+BasePayPalView.prototype.initialize = function () {
   var asyncDependencyTimeoutHandler;
+  var isCredit = Boolean(this._isPayPalCredit);
   var setupComplete = false;
   var self = this;
   var paypalType = isCredit ? 'paypalCredit' : 'paypal';

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -14,15 +14,13 @@ var cardIconHTML = fs.readFileSync(__dirname + '/../../html/card-icons.html', 'u
 
 function CardView() {
   BaseView.apply(this, arguments);
-
-  this._initialize();
 }
 
 CardView.prototype = Object.create(BaseView.prototype);
 CardView.prototype.constructor = CardView;
 CardView.ID = CardView.prototype.ID = constants.paymentOptionIDs.card;
 
-CardView.prototype._initialize = function () {
+CardView.prototype.initialize = function () {
   var cvvFieldGroup, postalCodeFieldGroup;
   var cardholderNameField = this.getElementById('cardholder-name-field-group');
   var cardIcons = this.getElementById('card-view-icons');

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -57,15 +57,7 @@ CardView.prototype.initialize = function () {
 
   this.model.asyncDependencyStarting();
 
-  hostedFields.create(hfOptions, function (err, hostedFieldsInstance) {
-    if (err) {
-      this.model.asyncDependencyFailed({
-        view: this.ID,
-        error: err
-      });
-      return;
-    }
-
+  return hostedFields.create(hfOptions).then(function (hostedFieldsInstance) {
     this.hostedFieldsInstance = hostedFieldsInstance;
     this.hostedFieldsInstance.on('blur', this._onBlurEvent.bind(this));
     this.hostedFieldsInstance.on('cardTypeChange', this._onCardTypeChangeEvent.bind(this));
@@ -74,6 +66,11 @@ CardView.prototype.initialize = function () {
     this.hostedFieldsInstance.on('validityChange', this._onValidityChangeEvent.bind(this));
 
     this.model.asyncDependencyReady();
+  }.bind(this)).catch(function (err) {
+    this.model.asyncDependencyFailed({
+      view: this.ID,
+      error: err
+    });
   }.bind(this));
 };
 

--- a/src/views/payment-sheet-views/paypal-credit-view.js
+++ b/src/views/payment-sheet-views/paypal-credit-view.js
@@ -6,7 +6,7 @@ var BasePayPalView = require('./base-paypal-view');
 function PayPalCreditView() {
   BasePayPalView.apply(this, arguments);
 
-  this._initialize(true);
+  this._isPayPalCredit = true;
 }
 
 PayPalCreditView.prototype = Object.create(BasePayPalView.prototype);

--- a/src/views/payment-sheet-views/paypal-view.js
+++ b/src/views/payment-sheet-views/paypal-view.js
@@ -5,8 +5,6 @@ var BasePayPalView = require('./base-paypal-view');
 
 function PayPalView() {
   BasePayPalView.apply(this, arguments);
-
-  this._initialize(false);
 }
 
 PayPalView.prototype = Object.create(BasePayPalView.prototype);

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -34,7 +34,7 @@ describe('Dropin', function () {
     };
 
     this.sandbox.stub(CardView.prototype, 'getPaymentMethod');
-    this.sandbox.stub(hostedFields, 'create').yieldsAsync(null, fake.hostedFieldsInstance);
+    this.sandbox.stub(hostedFields, 'create').resolves(fake.hostedFieldsInstance);
     this.sandbox.stub(paypalCheckout, 'create').yieldsAsync(null, fake.paypalInstance);
   });
 
@@ -111,7 +111,7 @@ describe('Dropin', function () {
       var paypalError = new Error('PayPal Error');
       var hostedFieldsError = new Error('HostedFields Error');
 
-      hostedFields.create.yieldsAsync(hostedFieldsError);
+      hostedFields.create.rejects(hostedFieldsError);
       paypalCheckout.create.yieldsAsync(paypalError);
 
       this.sandbox.stub(analytics, 'sendEvent');
@@ -132,7 +132,7 @@ describe('Dropin', function () {
       var instance;
       var hostedFieldsError = new Error('HostedFields Error');
 
-      hostedFields.create.yieldsAsync(hostedFieldsError);
+      hostedFields.create.rejects(hostedFieldsError);
       this.dropinOptions.merchantConfiguration.paypal = {flow: 'vault'};
 
       instance = new Dropin(this.dropinOptions);

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -28,7 +28,7 @@ describe('MainView', function () {
       getConfiguration: fake.configuration
     };
     this.sandbox.stub(CardView.prototype, 'getPaymentMethod');
-    this.sandbox.stub(BasePayPalView.prototype, '_initialize');
+    this.sandbox.stub(BasePayPalView.prototype, 'initialize');
   });
 
   describe('Constructor', function () {
@@ -560,7 +560,7 @@ describe('MainView', function () {
         strings: strings
       };
 
-      this.sandbox.stub(CardView.prototype, '_initialize');
+      this.sandbox.stub(CardView.prototype, 'initialize');
       this.sandbox.spy(MainView.prototype, 'hideLoadingIndicator');
 
       this.mainView = new MainView(this.mainViewOptions);

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -11,7 +11,7 @@ var classlist = require('../../../src/lib/classlist');
 var DropinModel = require('../../../src/dropin-model');
 var fake = require('../../helpers/fake');
 var fs = require('fs');
-var HostedFields = require('braintree-web/hosted-fields');
+var hostedFields = require('braintree-web/hosted-fields');
 var PaymentOptionsView = require('../../../src/views/payment-options-view');
 var PayPalView = require('../../../src/views/payment-sheet-views/paypal-view');
 var PayPalCheckout = require('braintree-web/paypal-checkout');
@@ -868,7 +868,7 @@ describe('MainView', function () {
 
         this.wrapper = document.createElement('div');
         this.wrapper.innerHTML = templateHTML;
-        this.sandbox.stub(HostedFields, 'create').returns(null, fake.HostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(fake.HostedFieldsInstance);
         this.mainView = new MainView({
           element: this.wrapper,
           client: this.client,

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -64,7 +64,7 @@ describe('BasePayPalView', function () {
     });
   });
 
-  describe('_initialize', function () {
+  describe('initialize', function () {
     beforeEach(function () {
       this.view = new BasePayPalView(this.paypalViewOptions);
     });
@@ -72,7 +72,7 @@ describe('BasePayPalView', function () {
     it('starts async dependency', function (done) {
       this.sandbox.stub(this.view.model, 'asyncDependencyStarting');
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.view.model.asyncDependencyStarting).to.be.calledOnce;
@@ -83,7 +83,7 @@ describe('BasePayPalView', function () {
     it('notifies async dependency', function (done) {
       this.sandbox.stub(this.view.model, 'asyncDependencyReady');
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.view.model.asyncDependencyReady).to.be.calledOnce;
@@ -92,14 +92,14 @@ describe('BasePayPalView', function () {
     });
 
     it('clones the PayPal config', function () {
-      this.view._initialize();
+      this.view.initialize();
 
       expect(this.view.paypalConfiguration.flow).to.equal(this.model.merchantConfiguration.paypal.flow);
       expect(this.view.paypalConfiguration).to.not.equal(this.model.merchantConfiguration.paypal);
     });
 
     it('creates a PayPal Checkout component', function (done) {
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(PayPalCheckout.create).to.be.calledWith(this.sandbox.match({
@@ -120,7 +120,7 @@ describe('BasePayPalView', function () {
 
       this.view.ID = 'fake-id';
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.view.model.asyncDependencyFailed).to.be.calledOnce;
@@ -140,13 +140,13 @@ describe('BasePayPalView', function () {
       PayPalCheckout.create.yieldsAsync(fakeError);
 
       this.sandbox.stub(DropinModel.prototype, 'asyncDependencyStarting');
-      this.view._initialize();
+      this.view.initialize();
 
       expect(this.view.model.asyncDependencyStarting).to.be.calledOnce;
     });
 
     it('calls paypal.Button.render', function (done) {
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledOnce;
@@ -161,7 +161,7 @@ describe('BasePayPalView', function () {
         color: 'orange',
         shape: 'rect'
       };
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -182,7 +182,8 @@ describe('BasePayPalView', function () {
         color: 'orange',
         shape: 'rect'
       };
-      this.view._initialize(true);
+      this.view._isPayPalCredit = true;
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -202,7 +203,8 @@ describe('BasePayPalView', function () {
       this.view.model.merchantConfiguration.paypalCredit.buttonStyle = {
         label: 'buynow'
       };
-      this.view._initialize(true);
+      this.view._isPayPalCredit = true;
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -216,7 +218,7 @@ describe('BasePayPalView', function () {
 
     it('sets paypal-checkout.js environment to production when gatewayConfiguration is production', function (done) {
       this.configuration.gatewayConfiguration.environment = 'production';
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -228,7 +230,7 @@ describe('BasePayPalView', function () {
 
     it('sets paypal-checkout.js environment to sandbox when gatewayConfiguration is not production', function (done) {
       this.configuration.gatewayConfiguration.environment = 'development';
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -247,7 +249,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var paymentFunction = this.paypal.Button.render.getCall(0).args[0].payment;
@@ -269,7 +271,7 @@ describe('BasePayPalView', function () {
 
       model.merchantConfiguration.locale = fakeLocaleCode;
 
-      view._initialize();
+      view.initialize();
 
       waitForInitialize(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -287,7 +289,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var paymentFunction = this.paypal.Button.render.getCall(0).args[0].payment;
@@ -306,7 +308,7 @@ describe('BasePayPalView', function () {
       this.sandbox.stub(this.model, 'asyncDependencyFailed');
       this.paypal.Button.render.rejects(error);
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         expect(this.model.asyncDependencyFailed).to.be.calledOnce;
@@ -330,7 +332,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onAuthFunction = this.paypal.Button.render.getCall(0).args[0].onAuthorize;
@@ -368,7 +370,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onAuthFunction = this.paypal.Button.render.getCall(0).args[0].onAuthorize;
@@ -405,7 +407,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onAuthFunction = this.paypal.Button.render.getCall(0).args[0].onAuthorize;
@@ -442,7 +444,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onAuthFunction = this.paypal.Button.render.getCall(0).args[0].onAuthorize;
@@ -474,7 +476,7 @@ describe('BasePayPalView', function () {
 
       this.paypal.Button.render.resolves();
 
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onAuthFunction = this.paypal.Button.render.getCall(0).args[0].onAuthorize;
@@ -497,7 +499,7 @@ describe('BasePayPalView', function () {
       var model = this.model;
 
       this.paypal.Button.render.resolves();
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onErrorFunction = this.paypal.Button.render.getCall(0).args[0].onError;
@@ -523,7 +525,7 @@ describe('BasePayPalView', function () {
           'catch': this.sandbox.stub()
         })
       });
-      this.view._initialize();
+      this.view.initialize();
 
       waitForInitialize(function () {
         var onErrorFunction = this.paypal.Button.render.getCall(0).args[0].onError;
@@ -551,7 +553,7 @@ describe('BasePayPalView', function () {
           flow: 'checkout'
         };
 
-        this.view._initialize(false);
+        this.view.initialize();
 
         expect(this.view.paypalConfiguration.flow).to.equal('vault');
       });
@@ -564,7 +566,7 @@ describe('BasePayPalView', function () {
           offerCredit: true
         };
 
-        this.view._initialize(false);
+        this.view.initialize();
 
         waitForInitialize(function () {
           expect(this.view.paypalConfiguration).to.deep.equal({
@@ -578,7 +580,7 @@ describe('BasePayPalView', function () {
       });
 
       it('uses the PayPal button selector', function (done) {
-        this.view._initialize(false);
+        this.view.initialize();
 
         waitForInitialize(function () {
           expect(this.paypal.Button.render).to.be.calledWith(this.sandbox.match.object, '[data-braintree-id="paypal-button"]');
@@ -596,7 +598,8 @@ describe('BasePayPalView', function () {
           flow: 'checkout'
         };
 
-        this.view._initialize(true);
+        this.view._isPayPalCredit = true;
+        this.view.initialize();
 
         expect(this.view.paypalConfiguration.flow).to.equal('checkout');
       });
@@ -608,7 +611,8 @@ describe('BasePayPalView', function () {
           currency: 'USD'
         };
 
-        this.view._initialize(true);
+        this.view._isPayPalCredit = true;
+        this.view.initialize();
 
         waitForInitialize(function () {
           expect(this.view.paypalConfiguration).to.deep.equal({
@@ -629,7 +633,8 @@ describe('BasePayPalView', function () {
           offerCredit: false
         };
 
-        this.view._initialize(true);
+        this.view._isPayPalCredit = true;
+        this.view.initialize();
 
         waitForInitialize(function () {
           expect(this.view.paypalConfiguration).to.deep.equal({
@@ -643,7 +648,8 @@ describe('BasePayPalView', function () {
       });
 
       it('uses the PayPal Credit button selector', function (done) {
-        this.view._initialize(true);
+        this.view._isPayPalCredit = true;
+        this.view.initialize();
 
         waitForInitialize(function () {
           expect(this.paypal.Button.render).to.be.calledWith(this.sandbox.match.object, '[data-braintree-id="paypal-credit-button"]');
@@ -652,7 +658,8 @@ describe('BasePayPalView', function () {
       });
 
       it('includes credit style in button configuration', function (done) {
-        this.view._initialize(true);
+        this.view._isPayPalCredit = true;
+        this.view.initialize();
 
         waitForInitialize(function () {
           expect(this.paypal.Button.render).to.be.calledWithMatch({
@@ -670,7 +677,7 @@ describe('BasePayPalView', function () {
         this.sandbox.stub(DropinModel.prototype, 'asyncDependencyFailed');
 
         this.paypal.Button.render.rejects();
-        this.view._initialize();
+        this.view.initialize();
 
         this.sandbox.clock.tick(30001);
 
@@ -692,7 +699,7 @@ describe('BasePayPalView', function () {
           })
         });
 
-        this.view._initialize();
+        this.view.initialize();
         this.sandbox.clock.tick(10);
 
         this.sandbox.clock.tick(300001);
@@ -708,7 +715,7 @@ describe('BasePayPalView', function () {
         PayPalCheckout.create.yields(null, this.paypalInstance);
         this.paypal.Button.render.rejects();
 
-        this.view._initialize();
+        this.view.initialize();
 
         onErrorFunction = this.paypal.Button.render.getCall(0).args[0].onError;
         err = new Error('Some error');

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -49,7 +49,7 @@ describe('CardView', function () {
       this.hostedFieldsInstance = {
         on: this.sandbox.spy()
       };
-      this.sandbox.stub(hostedFields, 'create').yields(null, this.hostedFieldsInstance);
+      this.sandbox.stub(hostedFields, 'create').resolves(this.hostedFieldsInstance);
 
       this.model = new DropinModel(fake.modelOptions());
     });
@@ -73,9 +73,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).to.exist;
+      }.bind(this));
     });
 
     it('does not have cvv if supplied in challenges, but hosted fields overrides sets cvv to null', function () {
@@ -105,9 +106,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
+      }.bind(this));
     });
 
     it('does not have cvv if not supplied in challenges', function () {
@@ -118,9 +120,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
+      }.bind(this));
     });
 
     it('has postal code if supplied in challenges', function () {
@@ -142,9 +145,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).to.exist;
+      }.bind(this));
     });
 
     it('does not have postal code if supplied in challenges, but hosted fields overrides sets postal code to null', function () {
@@ -174,9 +178,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
+      }.bind(this));
     });
 
     it('does not have postal code if not supplied in challenges', function () {
@@ -187,9 +192,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
+      }.bind(this));
     });
 
     it('has cardholderName if provided in merchant configuration', function () {
@@ -204,9 +210,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="cardholder-name-field-group"]')).to.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="cardholder-name-field-group"]')).to.exist;
+      }.bind(this));
     });
 
     it('does not include cardholderName if not provided in merchant configuration', function () {
@@ -219,9 +226,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.element.querySelector('[data-braintree-id="cardholder-name-field-group"]')).to.not.exist;
+      return this.view.initialize().then(function () {
+        expect(this.element.querySelector('[data-braintree-id="cardholder-name-field-group"]')).to.not.exist;
+      }.bind(this));
     });
 
     it('starts async dependency', function () {
@@ -234,15 +242,14 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(DropinModel.prototype.asyncDependencyStarting).to.be.calledOnce;
+      return this.view.initialize().then(function () {
+        expect(DropinModel.prototype.asyncDependencyStarting).to.be.calledOnce;
+      });
     });
 
     it('notifies async dependency is ready when Hosted Fields is created', function () {
       this.sandbox.spy(DropinModel.prototype, 'asyncDependencyReady');
-
-      hostedFields.create.callsArgWith(1, null, {on: function () {}});
 
       this.view = new CardView({
         element: this.element,
@@ -251,9 +258,10 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(DropinModel.prototype.asyncDependencyReady).to.be.calledOnce;
+      return this.view.initialize().then(function () {
+        expect(DropinModel.prototype.asyncDependencyReady).to.be.calledOnce;
+      });
     });
 
     it('creates Hosted Fields with number and expiration date', function () {
@@ -264,17 +272,18 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(hostedFields.create).to.be.calledWith(this.sandbox.match({
-        client: this.client,
-        fields: {
-          number: {},
-          expirationDate: {}
-        }
-      }), this.sandbox.match.func);
-      expect(hostedFields.create.lastCall.args[0]).not.to.have.deep.property('fields.cvv');
-      expect(hostedFields.create.lastCall.args[0]).not.to.have.deep.property('fields.postalCode');
+      return this.view.initialize().then(function () {
+        expect(hostedFields.create).to.be.calledWith(this.sandbox.match({
+          client: this.client,
+          fields: {
+            number: {},
+            expirationDate: {}
+          }
+        }));
+        expect(hostedFields.create.lastCall.args[0]).not.to.have.deep.property('fields.cvv');
+        expect(hostedFields.create.lastCall.args[0]).not.to.have.deep.property('fields.postalCode');
+      }.bind(this));
     });
 
     it('creates Hosted Fields with cvv if included in challenges', function () {
@@ -299,9 +308,10 @@ describe('CardView', function () {
           authorization: fake.clientToken
         }
       });
-      this.view.initialize();
 
-      expect(hostedFields.create.lastCall.args[0]).to.have.deep.property('fields.cvv');
+      return this.view.initialize().then(function () {
+        expect(hostedFields.create.lastCall.args[0]).to.have.deep.property('fields.cvv');
+      });
     });
 
     it('creates Hosted Fields with postal code if included in challenges', function () {
@@ -326,9 +336,10 @@ describe('CardView', function () {
           authorization: fake.clientToken
         }
       });
-      this.view.initialize();
 
-      expect(hostedFields.create.lastCall.args[0]).to.have.deep.property('fields.postalCode');
+      return this.view.initialize().then(function () {
+        expect(hostedFields.create.lastCall.args[0]).to.have.deep.property('fields.postalCode');
+      });
     });
 
     it('calls asyncDependencyFailed with an error when Hosted Fields creation fails', function () {
@@ -336,7 +347,7 @@ describe('CardView', function () {
         code: 'A_REAL_ERROR_CODE'
       };
 
-      hostedFields.create.yields(fakeError);
+      hostedFields.create.rejects(fakeError);
       this.sandbox.stub(this.model, 'asyncDependencyFailed');
 
       this.view = new CardView({
@@ -346,12 +357,13 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      expect(this.model.asyncDependencyFailed).to.be.calledWith({
-        view: 'card',
-        error: fakeError
-      });
+      return this.view.initialize().then(function () {
+        expect(this.model.asyncDependencyFailed).to.be.calledWith({
+          view: 'card',
+          error: fakeError
+        });
+      }.bind(this));
     });
 
     it('shows supported card icons', function () {
@@ -364,12 +376,13 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      supportedCardTypes.forEach(function (cardType) {
-        var cardIcon = this.element.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
+      return this.view.initialize().then(function () {
+        supportedCardTypes.forEach(function (cardType) {
+          var cardIcon = this.element.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
 
-        expect(cardIcon.classList.contains('braintree-hidden')).to.be.false;
+          expect(cardIcon.classList.contains('braintree-hidden')).to.be.false;
+        }.bind(this));
       }.bind(this));
     });
 
@@ -383,12 +396,13 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      unsupportedCardTypes.forEach(function (cardType) {
-        var cardIcon = this.element.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
+      return this.view.initialize().then(function () {
+        unsupportedCardTypes.forEach(function (cardType) {
+          var cardIcon = this.element.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
 
-        expect(cardIcon.classList.contains('braintree-hidden')).to.be.true;
+          expect(cardIcon.classList.contains('braintree-hidden')).to.be.true;
+        }.bind(this));
       }.bind(this));
     });
 
@@ -413,11 +427,12 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      unionPayCardIcon = this.element.querySelector('[data-braintree-id="unionpay-card-icon"]');
+      return this.view.initialize().then(function () {
+        unionPayCardIcon = this.element.querySelector('[data-braintree-id="unionpay-card-icon"]');
 
-      expect(unionPayCardIcon.classList.contains('braintree-hidden')).to.be.true;
+        expect(unionPayCardIcon.classList.contains('braintree-hidden')).to.be.true;
+      }.bind(this));
     });
 
     it('sets field placeholders', function () {
@@ -441,14 +456,15 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+      return this.view.initialize().then(function () {
+        hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
-      expect(hostedFieldsConfiguredFields.number.placeholder).to.equal('•••• •••• •••• ••••');
-      expect(hostedFieldsConfiguredFields.expirationDate.placeholder).to.equal(strings.expirationDatePlaceholder);
-      expect(hostedFieldsConfiguredFields.cvv.placeholder).to.equal('•••');
-      expect(hostedFieldsConfiguredFields.postalCode.placeholder).to.not.exist;
+        expect(hostedFieldsConfiguredFields.number.placeholder).to.equal('•••• •••• •••• ••••');
+        expect(hostedFieldsConfiguredFields.expirationDate.placeholder).to.equal(strings.expirationDatePlaceholder);
+        expect(hostedFieldsConfiguredFields.cvv.placeholder).to.equal('•••');
+        expect(hostedFieldsConfiguredFields.postalCode.placeholder).to.not.exist;
+      });
     });
 
     it('allows overriding field options for hosted fields', function () {
@@ -484,12 +500,13 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+      return this.view.initialize().then(function () {
+        hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
-      expect(hostedFieldsConfiguredFields.number.placeholder).to.equal('placeholder');
-      expect(hostedFieldsConfiguredFields.cvv.maxlength).to.equal(2);
+        expect(hostedFieldsConfiguredFields.number.placeholder).to.equal('placeholder');
+        expect(hostedFieldsConfiguredFields.cvv.maxlength).to.equal(2);
+      });
     });
 
     it('does not add hosted fields elements for fields that are not present', function () {
@@ -521,19 +538,18 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+      return this.view.initialize().then(function () {
+        hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
-      expect(hostedFieldsConfiguredFields.cvv).to.not.exist;
-      expect(hostedFieldsConfiguredFields.postalCode).to.not.exist;
-      expect(hostedFieldsConfiguredFields.expirationMonth).to.not.exist;
-      expect(hostedFieldsConfiguredFields.expirationYear).to.not.exist;
+        expect(hostedFieldsConfiguredFields.cvv).to.not.exist;
+        expect(hostedFieldsConfiguredFields.postalCode).to.not.exist;
+        expect(hostedFieldsConfiguredFields.expirationMonth).to.not.exist;
+        expect(hostedFieldsConfiguredFields.expirationYear).to.not.exist;
+      });
     });
 
     it('ignores changes to selector in field options', function () {
-      var hostedFieldsConfiguredFields;
-
       this.model.merchantConfiguration.card = {
         overrides: {
           fields: {
@@ -551,11 +567,12 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
+      return this.view.initialize().then(function () {
+        var hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
-      expect(hostedFieldsConfiguredFields.number.selector).to.not.equal('#some-selector');
+        expect(hostedFieldsConfiguredFields.number.selector).to.not.equal('#some-selector');
+      });
     });
 
     it('allows overriding styles options for hosted fields', function () {
@@ -581,24 +598,25 @@ describe('CardView', function () {
         client: this.client,
         strings: strings
       });
-      this.view.initialize();
 
-      hostedFieldsConfiguredStyles = hostedFields.create.lastCall.args[0].styles;
+      return this.view.initialize().then(function () {
+        hostedFieldsConfiguredStyles = hostedFields.create.lastCall.args[0].styles;
 
-      expect(hostedFieldsConfiguredStyles.input.color).to.equal('red');
-      expect(hostedFieldsConfiguredStyles.input.background).to.equal('blue');
-      expect(hostedFieldsConfiguredStyles.input['font-size']).to.equal('16px');
-      expect(hostedFieldsConfiguredStyles.input['font-family']).to.equal('fantasy');
-      expect(hostedFieldsConfiguredStyles[':focus']).to.not.exist;
-      expect(hostedFieldsConfiguredStyles['input::-ms-clear']).to.deep.equal({
-        color: 'transparent'
+        expect(hostedFieldsConfiguredStyles.input.color).to.equal('red');
+        expect(hostedFieldsConfiguredStyles.input.background).to.equal('blue');
+        expect(hostedFieldsConfiguredStyles.input['font-size']).to.equal('16px');
+        expect(hostedFieldsConfiguredStyles.input['font-family']).to.equal('fantasy');
+        expect(hostedFieldsConfiguredStyles[':focus']).to.not.exist;
+        expect(hostedFieldsConfiguredStyles['input::-ms-clear']).to.deep.equal({
+          color: 'transparent'
+        });
       });
     });
   });
 
   describe('requestPaymentMethod', function () {
     beforeEach(function () {
-      this.sandbox.stub(hostedFields, 'create').yields(null, fake.hostedFieldsInstance);
+      this.sandbox.stub(hostedFields, 'create').resolves(fake.hostedFieldsInstance);
 
       this.model = new DropinModel(fake.modelOptions());
     });
@@ -682,33 +700,33 @@ describe('CardView', function () {
       });
 
       it('shows default card icon in number field when focused', function () {
-        var cardNumberIcon;
         var hostedFieldsInstance = {
           on: this.sandbox.stub().callsArgWith(1, {emittedBy: 'number'})
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-        cardNumberIcon = this.element.querySelector('[data-braintree-id="card-number-icon"]');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          var cardNumberIcon = this.element.querySelector('[data-braintree-id="card-number-icon"]');
 
-        expect(cardNumberIcon.classList.contains('braintree-hidden')).to.be.false;
-        expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
+          expect(cardNumberIcon.classList.contains('braintree-hidden')).to.be.false;
+          expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
+        }.bind(this));
       });
 
       it('shows default cvv icon in cvv field when focused', function () {
-        var cvvIcon;
         var hostedFieldsInstance = {
           on: this.sandbox.stub().callsArgWith(1, {emittedBy: 'cvv'})
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-        cvvIcon = this.element.querySelector('[data-braintree-id="cvv-icon"]');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          var cvvIcon = this.element.querySelector('[data-braintree-id="cvv-icon"]');
 
-        expect(cvvIcon.classList.contains('braintree-hidden')).to.be.false;
-        expect(cvvIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCVVBack');
+          expect(cvvIcon.classList.contains('braintree-hidden')).to.be.false;
+          expect(cvvIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCVVBack');
+        }.bind(this));
       });
 
       it('adds braintree-form__field-group--is-focused', function () {
@@ -727,12 +745,12 @@ describe('CardView', function () {
         };
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--is-focused');
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.true;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.true;
+        });
       });
     });
 
@@ -755,12 +773,12 @@ describe('CardView', function () {
         };
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
         classlist.add(numberFieldGroup, 'braintree-form__field-group--is-focused');
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.false;
+        });
       });
 
       it('applies error class if field is not valid', function () {
@@ -796,12 +814,12 @@ describe('CardView', function () {
         };
 
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.true;
-        expect(numberFieldError.textContent).to.equal('This card number is not valid.');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.true;
+          expect(numberFieldError.textContent).to.equal('This card number is not valid.');
+        });
       });
 
       it('does apply error class if field is empty when focusing another hosted field', function () {
@@ -846,12 +864,12 @@ describe('CardView', function () {
         this.context.model = new DropinModel(modelOptions);
 
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.true;
-        expect(numberFieldError.textContent).to.equal('Please fill out a card number.');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.true;
+          expect(numberFieldError.textContent).to.equal('Please fill out a card number.');
+        });
       });
 
       it('does not apply error class if field is empty and not focusing hosted fields', function () {
@@ -893,11 +911,11 @@ describe('CardView', function () {
         this.context.model = new DropinModel(modelOptions);
 
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        });
       });
 
       it('does not apply error class if field is empty and the active element is not an iframe', function () {
@@ -939,11 +957,11 @@ describe('CardView', function () {
         this.context.model = new DropinModel(modelOptions);
 
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        });
       });
     });
 
@@ -963,10 +981,11 @@ describe('CardView', function () {
           setAttribute: function () {}
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.true;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.true;
+        });
       });
 
       it('removes the card-type-known class when there is no possible card type', function () {
@@ -982,10 +1001,11 @@ describe('CardView', function () {
 
         classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
+        });
       });
 
       it('removes the card-type-known class when there are many possible card types', function () {
@@ -1001,10 +1021,11 @@ describe('CardView', function () {
 
         classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
+        });
       });
 
       it('updates the card number icon to the card type if there is one possible card type', function () {
@@ -1018,10 +1039,11 @@ describe('CardView', function () {
           setAttribute: function () {}
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#icon-master-card');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#icon-master-card');
+        });
       });
 
       it('updates the card number icon to the generic card if there are many possible card types', function () {
@@ -1035,10 +1057,11 @@ describe('CardView', function () {
           setAttribute: function () {}
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
+        });
       });
 
       it('updates the card icon to the generic card if there no card types', function () {
@@ -1052,10 +1075,11 @@ describe('CardView', function () {
           setAttribute: function () {}
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
+        });
       });
 
       it('updates the cvv icon to back icon for non-amex cards', function () {
@@ -1070,10 +1094,11 @@ describe('CardView', function () {
         };
 
         use.setAttribute('xlink:href', '#iconCVVFront');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(use.getAttribute('xlink:href')).to.equal('#iconCVVBack');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(use.getAttribute('xlink:href')).to.equal('#iconCVVBack');
+        });
       });
 
       it('updates the cvv icon to front icon for amex cards', function () {
@@ -1087,10 +1112,11 @@ describe('CardView', function () {
           setAttribute: function () {}
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(use.getAttribute('xlink:href')).to.equal('#iconCVVFront');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(use.getAttribute('xlink:href')).to.equal('#iconCVVFront');
+        });
       });
 
       it('updates the cvv label descriptor to four digits when card type is amex', function () {
@@ -1105,10 +1131,11 @@ describe('CardView', function () {
         };
 
         cvvLabelDescriptor.textContent = 'some value';
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(cvvLabelDescriptor.textContent).to.equal('(4 digits)');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(cvvLabelDescriptor.textContent).to.equal('(4 digits)');
+        });
       });
 
       it('updates the cvv label descriptor to three digits when card type is non-amex', function () {
@@ -1123,10 +1150,11 @@ describe('CardView', function () {
         };
 
         cvvLabelDescriptor.textContent = 'some value';
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(cvvLabelDescriptor.textContent).to.equal('(3 digits)');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(cvvLabelDescriptor.textContent).to.equal('(3 digits)');
+        });
       });
 
       it('updates the cvv label descriptor to three digits when multiple card types', function () {
@@ -1141,10 +1169,11 @@ describe('CardView', function () {
         };
 
         cvvLabelDescriptor.textContent = 'some value';
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(cvvLabelDescriptor.textContent).to.equal('(3 digits)');
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(cvvLabelDescriptor.textContent).to.equal('(3 digits)');
+        });
       });
 
       it('updates the cvv field placeholder when card type is amex', function () {
@@ -1157,10 +1186,11 @@ describe('CardView', function () {
           setAttribute: this.sandbox.spy()
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '••••'});
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '••••'});
+        });
       });
 
       it('updates the cvv field placeholder when card type is non-amex', function () {
@@ -1173,10 +1203,11 @@ describe('CardView', function () {
           setAttribute: this.sandbox.spy()
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
+        });
       });
 
       it('updates the cvv field placeholder when multiple card types', function () {
@@ -1189,10 +1220,11 @@ describe('CardView', function () {
           setAttribute: this.sandbox.spy()
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
+        });
       });
 
       it('does not update the cvv field placeholder when there is no cvv challenge', function () {
@@ -1216,10 +1248,11 @@ describe('CardView', function () {
           };
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
+        });
       });
 
       it('does not update the cvv field placeholder when it is removed with an override', function () {
@@ -1240,10 +1273,11 @@ describe('CardView', function () {
           }
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
+        });
       });
 
       it('does not update the cvv field placeholder when using a custom CVV placeholder', function () {
@@ -1266,10 +1300,11 @@ describe('CardView', function () {
           }
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(hostedFieldsInstance.setAttribute).not.to.have.been.called;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(hostedFieldsInstance.setAttribute).not.to.have.been.called;
+        });
       });
     });
 
@@ -1298,11 +1333,11 @@ describe('CardView', function () {
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
         classlist.add(numberFieldGroup, 'braintree-form__field-group--has-error');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        });
       });
 
       it('adds braintree-form__field--valid class to valid expiration date field', function () {
@@ -1327,10 +1362,11 @@ describe('CardView', function () {
           removeAttribute: this.sandbox.stub()
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(expirationElement.classList.contains('braintree-form__field--valid')).to.equal(true);
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(expirationElement.classList.contains('braintree-form__field--valid')).to.equal(true);
+        });
       });
 
       it('removes braintree-form__field--valid class to invalid expiration date field', function () {
@@ -1355,10 +1391,11 @@ describe('CardView', function () {
           removeAttribute: this.sandbox.stub()
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(expirationElement.classList.contains('braintree-form__field--valid')).to.equal(false);
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(expirationElement.classList.contains('braintree-form__field--valid')).to.equal(false);
+        });
       });
 
       it('adds braintree-form__field--valid class to valid number with card type supported', function () {
@@ -1394,10 +1431,11 @@ describe('CardView', function () {
           };
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(true);
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(true);
+        });
       });
 
       it('removes braintree-form__field--valid class to valid number without card type supported', function () {
@@ -1433,10 +1471,11 @@ describe('CardView', function () {
           };
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(false);
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(false);
+        });
       });
 
       it('removes braintree-form__field--valid class to not valid number with card type supported', function () {
@@ -1472,10 +1511,11 @@ describe('CardView', function () {
           };
         };
 
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype.initialize.call(this.context);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(false);
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(false);
+        });
       });
 
       it('calls model.setPaymentMethodRequestable with isRequestable true if form is valid', function () {
@@ -1583,11 +1623,11 @@ describe('CardView', function () {
         var numberFieldGroup = this.element.querySelector('[data-braintree-id="number-field-group"]');
 
         classlist.add(numberFieldGroup, 'braintree-form__field-group--has-error');
-        this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
+        this.sandbox.stub(hostedFields, 'create').resolves(hostedFieldsInstance);
 
-        CardView.prototype.initialize.call(this.context);
-
-        expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        return CardView.prototype.initialize.call(this.context).then(function () {
+          expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
+        });
       });
     });
   });

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -36,13 +36,7 @@ describe('CardView', function () {
 
   describe('Constructor', function () {
     beforeEach(function () {
-      this.sandbox.stub(CardView.prototype, '_initialize');
-    });
-
-    it('calls _initialize', function () {
-      new CardView({element: this.element}); // eslint-disable-line no-new
-
-      expect(CardView.prototype._initialize).to.have.been.calledOnce;
+      this.sandbox.stub(CardView.prototype, 'initialize');
     });
 
     it('inherits from BaseView', function () {
@@ -50,7 +44,7 @@ describe('CardView', function () {
     });
   });
 
-  describe('_initialize', function () {
+  describe('initialize', function () {
     beforeEach(function () {
       this.hostedFieldsInstance = {
         on: this.sandbox.spy()
@@ -72,13 +66,14 @@ describe('CardView', function () {
         };
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).to.exist;
     });
@@ -103,25 +98,27 @@ describe('CardView', function () {
         }
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
     });
 
     it('does not have cvv if not supplied in challenges', function () {
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="cvv-field-group"]')).not.to.exist;
     });
@@ -138,13 +135,14 @@ describe('CardView', function () {
         };
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).to.exist;
     });
@@ -169,25 +167,27 @@ describe('CardView', function () {
         }
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
     });
 
     it('does not have postal code if not supplied in challenges', function () {
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="postal-code-field-group"]')).not.to.exist;
     });
@@ -197,13 +197,14 @@ describe('CardView', function () {
         cardholderName: true
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="cardholder-name-field-group"]')).to.exist;
     });
@@ -211,13 +212,14 @@ describe('CardView', function () {
     it('does not include cardholderName if not provided in merchant configuration', function () {
       this.model.merchantConfiguration.card = {};
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.element.querySelector('[data-braintree-id="cardholder-name-field-group"]')).to.not.exist;
     });
@@ -225,13 +227,14 @@ describe('CardView', function () {
     it('starts async dependency', function () {
       this.sandbox.spy(DropinModel.prototype, 'asyncDependencyStarting');
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(DropinModel.prototype.asyncDependencyStarting).to.be.calledOnce;
     });
@@ -241,25 +244,27 @@ describe('CardView', function () {
 
       hostedFields.create.callsArgWith(1, null, {on: function () {}});
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(DropinModel.prototype.asyncDependencyReady).to.be.calledOnce;
     });
 
     it('creates Hosted Fields with number and expiration date', function () {
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(hostedFields.create).to.be.calledWith(this.sandbox.match({
         client: this.client,
@@ -284,7 +289,7 @@ describe('CardView', function () {
         };
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
@@ -294,6 +299,7 @@ describe('CardView', function () {
           authorization: fake.clientToken
         }
       });
+      this.view.initialize();
 
       expect(hostedFields.create.lastCall.args[0]).to.have.deep.property('fields.cvv');
     });
@@ -310,7 +316,7 @@ describe('CardView', function () {
         };
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
@@ -320,6 +326,7 @@ describe('CardView', function () {
           authorization: fake.clientToken
         }
       });
+      this.view.initialize();
 
       expect(hostedFields.create.lastCall.args[0]).to.have.deep.property('fields.postalCode');
     });
@@ -332,13 +339,14 @@ describe('CardView', function () {
       hostedFields.create.yields(fakeError);
       this.sandbox.stub(this.model, 'asyncDependencyFailed');
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       expect(this.model.asyncDependencyFailed).to.be.calledWith({
         view: 'card',
@@ -349,13 +357,14 @@ describe('CardView', function () {
     it('shows supported card icons', function () {
       var supportedCardTypes = ['american-express', 'discover', 'jcb', 'master-card', 'visa'];
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       supportedCardTypes.forEach(function (cardType) {
         var cardIcon = this.element.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
@@ -367,13 +376,14 @@ describe('CardView', function () {
     it('hides unsupported card icons', function () {
       var unsupportedCardTypes = ['maestro', 'diners-club'];
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       unsupportedCardTypes.forEach(function (cardType) {
         var cardIcon = this.element.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
@@ -396,13 +406,14 @@ describe('CardView', function () {
         };
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       unionPayCardIcon = this.element.querySelector('[data-braintree-id="unionpay-card-icon"]');
 
@@ -423,13 +434,14 @@ describe('CardView', function () {
         };
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
@@ -465,13 +477,14 @@ describe('CardView', function () {
         }
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
@@ -501,13 +514,14 @@ describe('CardView', function () {
         }
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
@@ -530,13 +544,14 @@ describe('CardView', function () {
         }
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       hostedFieldsConfiguredFields = hostedFields.create.lastCall.args[0].fields;
 
@@ -559,13 +574,14 @@ describe('CardView', function () {
         }
       };
 
-      new CardView({ // eslint-disable-line no-new
+      this.view = new CardView({
         element: this.element,
         mainView: this.mainView,
         model: this.model,
         client: this.client,
         strings: strings
       });
+      this.view.initialize();
 
       hostedFieldsConfiguredStyles = hostedFields.create.lastCall.args[0].styles;
 
@@ -673,7 +689,7 @@ describe('CardView', function () {
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
         cardNumberIcon = this.element.querySelector('[data-braintree-id="card-number-icon"]');
 
         expect(cardNumberIcon.classList.contains('braintree-hidden')).to.be.false;
@@ -688,7 +704,7 @@ describe('CardView', function () {
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
         cvvIcon = this.element.querySelector('[data-braintree-id="cvv-icon"]');
 
         expect(cvvIcon.classList.contains('braintree-hidden')).to.be.false;
@@ -714,7 +730,7 @@ describe('CardView', function () {
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--is-focused');
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.true;
       });
@@ -742,7 +758,7 @@ describe('CardView', function () {
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
         classlist.add(numberFieldGroup, 'braintree-form__field-group--is-focused');
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--is-focused')).to.be.false;
       });
@@ -782,7 +798,7 @@ describe('CardView', function () {
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.true;
         expect(numberFieldError.textContent).to.equal('This card number is not valid.');
@@ -832,7 +848,7 @@ describe('CardView', function () {
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.true;
         expect(numberFieldError.textContent).to.equal('Please fill out a card number.');
@@ -879,7 +895,7 @@ describe('CardView', function () {
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
       });
@@ -925,7 +941,7 @@ describe('CardView', function () {
         classlist.remove(numberFieldGroup, 'braintree-form__field-group--has-error');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
       });
@@ -948,7 +964,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.true;
       });
@@ -967,7 +983,7 @@ describe('CardView', function () {
         classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
       });
@@ -986,7 +1002,7 @@ describe('CardView', function () {
         classlist.add(numberFieldGroup, 'braintree-form__field-group--card-type-known');
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--card-type-known')).to.be.false;
       });
@@ -1003,7 +1019,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#icon-master-card');
       });
@@ -1020,7 +1036,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
       });
@@ -1037,7 +1053,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(cardNumberIcon.querySelector('use').getAttribute('xlink:href')).to.equal('#iconCardFront');
       });
@@ -1055,7 +1071,7 @@ describe('CardView', function () {
 
         use.setAttribute('xlink:href', '#iconCVVFront');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(use.getAttribute('xlink:href')).to.equal('#iconCVVBack');
       });
@@ -1072,7 +1088,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(use.getAttribute('xlink:href')).to.equal('#iconCVVFront');
       });
@@ -1090,7 +1106,7 @@ describe('CardView', function () {
 
         cvvLabelDescriptor.textContent = 'some value';
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(cvvLabelDescriptor.textContent).to.equal('(4 digits)');
       });
@@ -1108,7 +1124,7 @@ describe('CardView', function () {
 
         cvvLabelDescriptor.textContent = 'some value';
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(cvvLabelDescriptor.textContent).to.equal('(3 digits)');
       });
@@ -1126,7 +1142,7 @@ describe('CardView', function () {
 
         cvvLabelDescriptor.textContent = 'some value';
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(cvvLabelDescriptor.textContent).to.equal('(3 digits)');
       });
@@ -1142,7 +1158,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '••••'});
       });
@@ -1158,7 +1174,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
       });
@@ -1174,7 +1190,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(hostedFieldsInstance.setAttribute).to.have.been.calledWith({field: 'cvv', attribute: 'placeholder', value: '•••'});
       });
@@ -1201,7 +1217,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
       });
@@ -1225,7 +1241,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(hostedFieldsInstance.setAttribute).to.not.have.been.called;
       });
@@ -1251,7 +1267,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(hostedFieldsInstance.setAttribute).not.to.have.been.called;
       });
@@ -1284,7 +1300,7 @@ describe('CardView', function () {
         classlist.add(numberFieldGroup, 'braintree-form__field-group--has-error');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
       });
@@ -1312,7 +1328,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(expirationElement.classList.contains('braintree-form__field--valid')).to.equal(true);
       });
@@ -1340,7 +1356,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(expirationElement.classList.contains('braintree-form__field--valid')).to.equal(false);
       });
@@ -1379,7 +1395,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(true);
       });
@@ -1418,7 +1434,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(false);
       });
@@ -1457,7 +1473,7 @@ describe('CardView', function () {
         };
 
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberElement.classList.contains('braintree-form__field--valid')).to.equal(false);
       });
@@ -1569,7 +1585,7 @@ describe('CardView', function () {
         classlist.add(numberFieldGroup, 'braintree-form__field-group--has-error');
         this.sandbox.stub(hostedFields, 'create').yields(null, hostedFieldsInstance);
 
-        CardView.prototype._initialize.call(this.context);
+        CardView.prototype.initialize.call(this.context);
 
         expect(numberFieldGroup.classList.contains('braintree-form__field-group--has-error')).to.be.false;
       });
@@ -2078,7 +2094,7 @@ describe('CardView', function () {
     it('focuses on the number field', function () {
       var view;
 
-      this.sandbox.stub(CardView.prototype, '_initialize');
+      this.sandbox.stub(CardView.prototype, 'initialize');
 
       view = new CardView({element: this.element});
 
@@ -2095,7 +2111,7 @@ describe('CardView', function () {
     it('noops if the hosted fields instance is not available', function () {
       var view;
 
-      this.sandbox.stub(CardView.prototype, '_initialize');
+      this.sandbox.stub(CardView.prototype, 'initialize');
 
       view = new CardView({element: this.element});
 

--- a/test/unit/views/payment-sheet-views/paypal-credit-view.js
+++ b/test/unit/views/payment-sheet-views/paypal-credit-view.js
@@ -6,14 +6,7 @@ var PayPalCreditView = require('../../../../src/views/payment-sheet-views/paypal
 
 describe('PayPalCreditView', function () {
   beforeEach(function () {
-    this.sandbox.stub(PayPalCreditView.prototype, '_initialize');
-  });
-
-  it('calls _initialize with true for isCredit', function () {
-    new PayPalCreditView();
-
-    expect(PayPalCreditView.prototype._initialize).to.have.been.calledOnce;
-    expect(PayPalCreditView.prototype._initialize).to.have.been.calledWith(true);
+    this.sandbox.stub(PayPalCreditView.prototype, 'initialize');
   });
 
   it('inherits from BasePayPalView', function () {

--- a/test/unit/views/payment-sheet-views/paypal-view.js
+++ b/test/unit/views/payment-sheet-views/paypal-view.js
@@ -6,14 +6,7 @@ var PayPalView = require('../../../../src/views/payment-sheet-views/paypal-view'
 
 describe('PayPalView', function () {
   beforeEach(function () {
-    this.sandbox.stub(PayPalView.prototype, '_initialize');
-  });
-
-  it('calls _initialize with false for isCredit', function () {
-    new PayPalView();
-
-    expect(PayPalView.prototype._initialize).to.have.been.calledOnce;
-    expect(PayPalView.prototype._initialize).to.have.been.calledWith(false);
+    this.sandbox.stub(PayPalView.prototype, 'initialize');
   });
 
   it('inherits from BasePayPalView', function () {


### PR DESCRIPTION
### Summary

We call `_initialize` within the constructor for the payment sheet views. This causes side effects beyond instantiating a view.

Instead, we should call `initialize` after creating the view and allow `initialize` to return a promise so we can test it easier.

(this will also make adding unionpay support easier)

PayPal should also be converted, but I have not completed the work yet.

### Checklist

- [ ] ~~Added a changelog entry~~ (internal change only)
