### PR TITLE
Document binData and standardize requestPaymentMethod payload

### DIFF
--- a/src/dropin.js
+++ b/src/dropin.js
@@ -40,6 +40,7 @@ var VERSION = process.env.npm_package_version;
  * @property {string} details.lastTwo Last two digits of card number.
  * @property {string} description A human-readable description.
  * @property {string} type The payment method type, always `CreditCard` when the method requested is a card.
+ * @property {object} binData Information about the card based on the bin. Documented {@link Dropin~binData|here}.
  * @property {?string} deviceData If data collector is configured, the device data property to be used when making a transaction.
  */
 
@@ -49,6 +50,19 @@ var VERSION = process.env.npm_package_version;
  * @property {object} details Additional PayPal account details. See a full list of details in the [PayPal client reference](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/PayPalCheckout.html#~tokenizePayload).
  * @property {string} type The payment method type, always `PayPalAccount` when the method requested is a PayPal account.
  * @property {?string} deviceData If data collector is configured, the device data property to be used when making a transaction.
+ */
+
+/**
+ * @typedef {object} Dropin~binData Information about the card based on the bin.
+ * @property {string} commercial Possible values: 'Yes', 'No', 'Unknown'.
+ * @property {string} countryOfIssuance The country of issuance.
+ * @property {string} debit Possible values: 'Yes', 'No', 'Unknown'.
+ * @property {string} durbinRegulated Possible values: 'Yes', 'No', 'Unknown'.
+ * @property {string} healthcare Possible values: 'Yes', 'No', 'Unknown'.
+ * @property {string} issuingBank The issuing bank.
+ * @property {string} payroll Possible values: 'Yes', 'No', 'Unknown'.
+ * @property {string} prepaid Possible values: 'Yes', 'No', 'Unknown'.
+ * @property {string} productId The product id.
  */
 
 /**

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -515,12 +515,8 @@ Dropin.prototype._disableErroredPaymentMethods = function () {
  */
 Dropin.prototype.requestPaymentMethod = function () {
   return this._mainView.requestPaymentMethod().then(function (payload) {
-    if (this._dataCollectorInstance) {
-      payload.deviceData = this._dataCollectorInstance.deviceData;
-    }
-
-    return payload;
-  }.bind(this));
+    return formatPaymentMethodPayload(payload);
+  });
 };
 
 Dropin.prototype._removeStylesheet = function () {
@@ -647,6 +643,14 @@ function formatPaymentMethodPayload(paymentMethod) {
 
   if (paymentMethod.type === constants.paymentMethodTypes.card) {
     formattedPaymentMethod.description = paymentMethod.description;
+  }
+
+  if (paymentMethod.deviceData) {
+    formattedPaymentMethod.deviceData = paymentMethod.deviceData;
+  }
+
+  if (paymentMethod.binData) {
+    formattedPaymentMethod.binData = paymentMethod.binData;
   }
 
   return formattedPaymentMethod;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -515,8 +515,12 @@ Dropin.prototype._disableErroredPaymentMethods = function () {
  */
 Dropin.prototype.requestPaymentMethod = function () {
   return this._mainView.requestPaymentMethod().then(function (payload) {
+    if (this._dataCollectorInstance) {
+      payload.deviceData = this._dataCollectorInstance.deviceData;
+    }
+
     return formatPaymentMethodPayload(payload);
-  });
+  }.bind(this));
 };
 
 Dropin.prototype._removeStylesheet = function () {

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -8,6 +8,7 @@ var fake = require('../helpers/fake');
 var hostedFields = require('braintree-web/hosted-fields');
 var paypalCheckout = require('braintree-web/paypal-checkout');
 var dataCollector = require('braintree-web/data-collector');
+var MainView = require('../../src/views/main-view');
 var CardView = require('../../src/views/payment-sheet-views/card-view');
 var constants = require('../../src/constants');
 var checkoutJsSource = constants.CHECKOUT_JS_SOURCE;
@@ -731,6 +732,23 @@ describe('Dropin', function () {
         expect(err._braintreeWebError).to.equal(dataCollectorError);
 
         done();
+      });
+    });
+
+    it('passes along device data when requesting payment method', function (done) {
+      var instance = new Dropin(this.dropinOptions);
+      var deviceData = this.deviceData;
+
+      this.sandbox.stub(MainView.prototype, 'requestPaymentMethod').resolves({
+        nonce: 'a-nonce'
+      });
+
+      instance._initialize(function () {
+        instance.requestPaymentMethod(function (err, payload) {
+          expect(payload.nonce).to.equal('a-nonce');
+          expect(payload.deviceData).to.equal(deviceData);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
### Summary
Previously, we were only formatting vaulted payment methods. This formats all payment methods before returning them in `requestPaymentMethod`. In the future we'll have to add new params to be returned.

We also document `binData`.
### Checklist

~[ ] Added a changelog entry~
