### PR TITLE
Get package version from package.json in gh-pages script

### DIFF
--- a/scripts/deploy-gh-pages
+++ b/scripts/deploy-gh-pages
@@ -12,10 +12,14 @@ commit_and_push() {
   set +e
   git add .
   echo -e "Committing and pushing new gh-pages...\n"
-  git commit -m "Add version $npm_package_version"
+  git commit -m "Add version $(get_package_json_version)"
   run_ressh
   git push origin gh-pages
   set -e
+}
+
+get_package_json_version() {
+  grep \"version\" package.json | cut -d':' -f2- | tr -d '" ,'
 }
 
 BT_DROPIN_DIR=~/bt/braintree-web-drop-in


### PR DESCRIPTION
### Summary
The npm_package_version environmental variable wasn't always present when running the gh-pages script, this grabs the version from the package.json. 

### Checklist

~- [ ] Added a changelog entry~
