### PR TITLE
Simplify checkout.js script check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Simplify check for checkout.js on the merchant's page
+
 1.7.0
 ------
 - Add data collector
@@ -27,7 +31,7 @@ CHANGELOG
 - Add `clearSelectedPaymentMethod` to remove selected payment method
 
 1.4.0
-------
+-----
 - Add `paymentOptionSelected` event
 - Add support for PayPal and PayPal credit in the script tag integration
 - Add support for locale and payment option priority in the script tag integration

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -299,7 +299,7 @@ Dropin.prototype._initialize = function (callback) {
 
     paypalRequired = this._supportsPaymentOption(paymentOptionIDs.paypal) || this._supportsPaymentOption(paymentOptionIDs.paypalCredit);
 
-    if (paypalRequired && !document.querySelector('#' + constants.PAYPAL_CHECKOUT_SCRIPT_ID)) {
+    if (paypalRequired && !global.paypal) {
       paypalScriptOptions = {
         src: constants.CHECKOUT_JS_SOURCE,
         id: constants.PAYPAL_CHECKOUT_SCRIPT_ID,

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -506,20 +506,15 @@ describe('Dropin', function () {
       });
     });
 
-    it('does not load checkout.js if script tag with paypal checkout id is already on the page', function (done) {
+    it('does not load checkout.js if global paypal object is already on the page', function (done) {
       var instance = new Dropin(this.dropinOptions);
-      var script = document.createElement('script');
 
       global.paypal = this.paypalCheckout;
-
-      script.id = 'braintree-dropin-paypal-checkout-script';
-      document.body.appendChild(script);
 
       this.dropinOptions.merchantConfiguration.paypal = {flow: 'vault'};
 
       instance._initialize(function () {
         expect(instance._loadScript).to.not.have.been.called;
-        document.body.removeChild(script);
 
         done();
       });


### PR DESCRIPTION
### Summary

Will prevent warnings about checkout.js being loaded on the page already

If `paypal` is on the window object, it won't load anyway. This removes the need to check for a script tags presence and instead just checks for the `paypal` object. This will prevent checkout.js from issuing warnings about PayPal already being loaded.

### Checklist

- [x] Added a changelog entry
