### PR TITLE
Allow useraction to be set for PayPal button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+x.x.x
+------
+- Allow useraction to be set for PayPal button.
+
 1.7.0
 ------
 - Add data collector

--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,7 @@ var VERSION = process.env.npm_package_version;
  * @param {string|number} [amount] The amount of the transaction. Required when using the Checkout flow.
  * @param {string} [currency] The currency code of the amount, such as `USD`. Required when using the Checkout flow.
  * @param {string} [buttonStyle] The style object to apply to the PayPal button. Button customization includes color, shape, size, and label. The options [found here](https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/customize-button/#button-styles) are available.
+ * @param {boolean} [commit] The user action to show on the PayPal review page. If true, a `Pay Now` button will be shown. If false, a `Continue` button will be shown.
  */
 
 /**

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -44,7 +44,7 @@ BasePayPalView.prototype.initialize = function () {
     checkoutJSConfiguration = {
       env: environment,
       style: self.paypalConfiguration.buttonStyle || {},
-      commit: self.paypalConfiguration.commit || false,
+      commit: self.paypalConfiguration.commit,
       locale: locale,
       payment: function () {
         return paypalInstance.createPayment(self.paypalConfiguration).catch(reportError);

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -44,6 +44,7 @@ BasePayPalView.prototype.initialize = function () {
     checkoutJSConfiguration = {
       env: environment,
       style: self.paypalConfiguration.buttonStyle || {},
+      commit: self.paypalConfiguration.commit || false,
       locale: locale,
       payment: function () {
         return paypalInstance.createPayment(self.paypalConfiguration).catch(reportError);

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -188,6 +188,24 @@ describe('BasePayPalView', function () {
       }.bind(this));
     });
 
+    it('can set user action to commit for the PayPal button', function () {
+      this.view.model.merchantConfiguration.paypal.commit = true;
+      return this.view.initialize().then(function () {
+        expect(this.paypal.Button.render).to.be.calledWithMatch({
+          commit: true
+        });
+      }.bind(this));
+    });
+
+    it('can set user action to continue for the PayPal button', function () {
+      this.view.model.merchantConfiguration.paypal.commit = false;
+      return this.view.initialize().then(function () {
+        expect(this.paypal.Button.render).to.be.calledWithMatch({
+          commit: false
+        });
+      }.bind(this));
+    });
+
     it('sets paypal-checkout.js environment to production when gatewayConfiguration is production', function () {
       this.configuration.gatewayConfiguration.environment = 'production';
       return this.view.initialize().then(function () {


### PR DESCRIPTION
### Summary
`paypal.button.render()` in PayPal's checkout.js accepts a `commit` parameter to control whether the customer sees a `Pay Now` or `Continue` experience on the PayPal review page.  By default, the `Continue` experience is shown, but it is often preferable to show the `Buy Now` experience.

When the final payment amount is known at the time the PayPal Checkout flow is initiated, and no further customer interaction is required before payment is attempted, the `Pay Now` experience should be used ([PayPal Best Practice](https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/best-practices/#implement-the-pay-now-experience)).

Switching to the `Pay Now` experience also results in the payment amount being shown on the PayPal review page.

### Checklist

- [x] Added a changelog entry
