### PR TITLE
Allow vaulted payment methods to not be pre-selected on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Simplify check for checkout.js on the merchant's page
 - Allow useraction to be set for PayPal button.
+- Allow vaulted payment methods to not be pre-selected on initialization
 
 1.7.0
 ------

--- a/src/index.js
+++ b/src/index.js
@@ -186,6 +186,7 @@ var VERSION = process.env.npm_package_version;
  * Some of the PayPal Credit configuration options are listed [here](#~paypalCreateOptions), but for a full list see the [PayPal Checkout client reference options](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/PayPalCheckout.html#createPayment). For more information on PayPal Credit, see the [Braintree Developer Docs](https://developers.braintreepayments.com/guides/paypal/paypal-credit/javascript/v3).
  *
  * @param {object} [options.dataCollector] The configuration options for data collector. See [`dataCollectorOptions`](#~dataCollectorOptions) for all `dataCollector` options. If Data Collector is configured and fails to load, Drop-in creation will fail.
+ * @param {boolean} [preselectVaultedPaymentMethod=true] Whether or not to initialize Drop-in with a vaulted payment method pre-selected. Only applicable when using a [client token with a customer id](https://developers.braintreepayments.com/reference/request/client-token/generate/#customer_id) and a customer with saved payment methods.
  *
  * @param {function} [callback] The second argument, `data`, is the {@link Dropin} instance. Returns a promise if no callback is provided.
  * @returns {void|Promise} Returns a promise if no callback is provided.

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -29,6 +29,7 @@ MainView.prototype._initialize = function () {
   var paymentOptionsView;
   var hasMultiplePaymentOptions = this.model.supportedPaymentOptions.length > 1;
   var paymentMethods = this.model.getPaymentMethods();
+  var preselectVaultedPaymentMethod = this.model.merchantConfiguration.preselectVaultedPaymentMethod !== false;
 
   this._views = {};
 
@@ -128,7 +129,11 @@ MainView.prototype._initialize = function () {
   }
 
   if (paymentMethods.length > 0) {
-    this.model.changeActivePaymentMethod(paymentMethods[0]);
+    if (preselectVaultedPaymentMethod) {
+      this.model.changeActivePaymentMethod(paymentMethods[0]);
+    } else {
+      this.setPrimaryView(this.paymentMethodsViews.ID);
+    }
   } else if (hasMultiplePaymentOptions) {
     this.setPrimaryView(paymentOptionsView.ID);
   } else {

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -132,6 +132,18 @@ describe('MainView', function () {
         expect(this.model.changeActivePaymentMethod).to.have.been.calledWith({type: 'CreditCard', details: {lastTwo: '11'}});
       });
 
+      it('does not set the first payment method to be the active payment method if configured not to', function () {
+        this.sandbox.spy(this.model, 'changeActivePaymentMethod');
+        this.model.merchantConfiguration.preselectVaultedPaymentMethod = false;
+        this.sandbox.stub(MainView.prototype, 'setPrimaryView');
+
+        new MainView(this.mainViewOptions); // eslint-disable-line no-new
+
+        expect(this.model.changeActivePaymentMethod).to.not.have.been.called;
+        expect(MainView.prototype.setPrimaryView).to.be.calledOnce;
+        expect(MainView.prototype.setPrimaryView).to.be.calledWith('methods');
+      });
+
       it('sets the PaymentMethodsView as the primary view', function (done) {
         var mainView = new MainView(this.mainViewOptions);
 


### PR DESCRIPTION
### Summary

Related to https://github.com/braintree/braintree-web-drop-in/issues/272

If you have a submit-button-less page, there's no way to know if a customer has selected a saved payment method because the default payment method comes pre-selected. Since it's pre-selected, the payment method request-able event doesn't fire (because it was already requestable). 

By providing an option to turn off pre-selection, when the customer selects a saved payment method, the event does fire.

### Checklist

- [x] Added a changelog entry
