### PR TITLE
Remove unused error from en_US strings

### DIFF
--- a/src/translations/en_US.js
+++ b/src/translations/en_US.js
@@ -6,7 +6,6 @@ module.exports = {
   chooseAWayToPay: 'Choose a way to pay',
   otherWaysToPay: 'Other ways to pay',
   // Errors
-  browserNotSupported: 'Browser not supported.',
   fieldEmptyForCvv: 'Please fill out a CVV.',
   fieldEmptyForExpirationDate: 'Please fill out an expiration date.',
   fieldEmptyForCardholderName: 'Please fill out a cardholder name.',


### PR DESCRIPTION
### Summary
Removes browser unsupported error, we used it when PayPal didn't support webviews.

### Checklist

~- [ ] Added a changelog entry~
