### PR TITLE
Udpate bt-web to v3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 unreleased
 ----------
-- Update braintree-web to v3.23.0
+- Update braintree-web to v3.24.0
 
 1.8.0
 -----

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.23.0",
+    "braintree-web": "3.24.0",
     "@braintree/browser-detection": "1.6.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary

Updates braintree-web to v3.24.0

### Checklist

- [x] Added a changelog entry
