### PR TITLE
Upgrade firefox driver to latest version

### DIFF
--- a/spec/sauce_helper.rb
+++ b/spec/sauce_helper.rb
@@ -16,7 +16,7 @@ def select_browsers
   if !PLATFORM || PLATFORM == "desktop"
     browsers += [
       ["Windows 10", "chrome", 56], # chrome 57 has a bug where iframes can't have characters sent into them
-      ["Windows 10", "firefox", 47],
+      ["Windows 10", "firefox", nil],
       # the Safari driver can't send keys
       # to inputs in iframes. Both hosted
       # fields and paypal use iframe inputs


### PR DESCRIPTION
### Summary

The latest version of the Firefox driver does not have the same issue that previous versions had where you could not inspect the values of inputs inside iframes.

### Checklist

- [ ] ~~Added a changelog entry~~
