### PR TITLE
Fix bug where style ovverrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ unreleased
 - Update browser-detection to v1.7.0
 - Fix issue where the edges of card form inputs were not clickable
   - This adds a label element to the Drop-in card form. If you have global styles for the label tag, it may affect the look of the Drop-in card form.
+- Fix issue where style overrides could not be applied if previous style rule did not exist
 
 1.8.0
 -----

--- a/spec/hosted_fields_overrides_spec.rb
+++ b/spec/hosted_fields_overrides_spec.rb
@@ -30,15 +30,17 @@ describe "Drop-in Hosted Fields Overrides" do
   end
 
   it "can override style configurations" do
-    options = '{"overrides":{"styles":{"input":{"font-size":"20px"}}}}'
+    options = '{"overrides":{"styles":{"input":{"font-size":"20px"},".number":{"font-size":"10px"}}}}'
     visit_dropin_url("?card=#{options}")
 
     click_option("card")
 
-    iframe = find("iframe[id='braintree-hosted-field-cvv']")
-
-    within_frame(iframe) do
+    within_frame(find("iframe[id='braintree-hosted-field-cvv']")) do
       expect(find("input").native.css_value("font-size")).to eq("20px")
+    end
+
+    within_frame(find("iframe[id='braintree-hosted-field-number']")) do
+      expect(find("input").native.css_value("font-size")).to eq("10px")
     end
   end
 end

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -207,6 +207,7 @@ CardView.prototype._generateHostedFieldsOptions = function () {
       }
 
       normalizeStyles(overrides.styles[style]);
+      options.styles[style] = options.styles[style] || {};
 
       assign(options.styles[style], overrides.styles[style]);
     });


### PR DESCRIPTION
### Summary

If a style override was provided that did not already exist, drop-in would fail to load.

### Checklist

- [x] Added a changelog entry
