### PR TITLE
Fix cardholder name field in script tag integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - Add 3D Secure support
 - Add Apple Pay support
 - Limit cardholder name length to 255 characters
+- Fix cardholder-name in script tag integration
 
 1.8.1
 -----

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@
  * Specify creation options as data attributes in your script tag, as shown in the examples below. The following configuration properties may be set:
  *
  * * `data-locale`
- * * `data-card.cardholder-name`
  * * `data-card.cardholder-name.required`
  * * `data-payment-option-priority`
  * * `data-data-collector.kount`
@@ -84,11 +83,11 @@
  * </form>
  *
  * @example
- * <caption>Including cardholder name field in card form</caption>
+ * <caption>Including an optional cardholder name field in card form</caption>
  * <form id="payment-form" action="/" method="post">
  *   <script src="https://js.braintreegateway.com/web/dropin/{@pkg version}/js/dropin.min.js"
  *    data-braintree-dropin-authorization="CLIENT_AUTHORIZATION"
- *    data-card.cardholder-name="true"
+ *    data-card.cardholder-name.required="false"
  *   ></script>
  *   <input type="submit" value="Purchase"></input>
  * </form>

--- a/src/lib/create-from-script-tag.js
+++ b/src/lib/create-from-script-tag.js
@@ -12,8 +12,13 @@ var WHITELISTED_DATA_ATTRIBUTES = [
   'data-collector.kount',
   'data-collector.paypal',
 
+  // camelcase version was accidentally used initially.
+  // we add the kebab case version to match the docs, but
+  // we retain the camelcase version for backwards compatibility
   'card.cardholderName',
   'card.cardholderName.required',
+  'card.cardholder-name',
+  'card.cardholder-name.required',
 
   'paypal.amount',
   'paypal.currency',


### PR DESCRIPTION
### Summary

We incorrectly had the cardholder name config in the script tag integration as `cardholderName` when it should be `cardholder-name`

### Checklist

- [x] Added a changelog entry
