### PR TITLE
Fix cardholder name validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - Add 3D Secure support
 - Add Apple Pay support
 - Limit cardholder name length to 255 characters
+- Show error for cardholder name when attempting to tokenize (#318)
 - Fix cardholder-name in script tag integration
 
 1.8.1


### PR DESCRIPTION
### Summary

We don't show errors for cardholder name when requesting a payment method. This fixes that.

This also cleans up some of the logic so there's less repetition.

### Checklist

- [x] Added a changelog entry
