### PR TITLE
Update braintree-web to v3.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ unreleased
 - Add Apple Pay support
 - Limit cardholder name length to 255 characters
 - Fix cardholder-name in script tag integration
+- Update braintree-web to v3.26.0
 
 1.8.1
 -----

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.25.0",
+    "braintree-web": "3.26.0",
     "@braintree/browser-detection": "1.7.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary
Updating `braintree-web` to 3.26.0

### Checklist

- [X] Added a changelog entry
