### PR TITLE
Fix style issues with label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+- Normalize label styles
+ - Fixes styling applied by frameworks like Bootstrap
+
 1.9.0
 -----
 - Add 3D Secure support (#208)

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -565,6 +565,8 @@ $loader-scale-duration: 300ms;
 
       label {
         cursor: text;
+        display: block;
+        margin: 0;
       }
 
       .braintree-form__icon-container {


### PR DESCRIPTION
### Summary

Bootstrap applies an `inline-block` style to all labels, which was making our inputs look like:


![screen shot 2017-11-15 at 11 10 10 am](https://user-images.githubusercontent.com/2916945/32850241-409a4c06-c9f7-11e7-823d-0737ee962843.png)

This normalizes the styles for labels in drop-in.

### Checklist

- [x] Added a changelog entry
