### PR TITLE
Fix apple pay enabled logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+==========
+
+Fix logic for Apple Pay being enabled (#324)
+
 1.9.0
 -----
 - Add 3D Secure support (#208)

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -214,7 +214,7 @@ function isPaymentOptionEnabled(paymentOption, options) {
   } else if (paymentOption === 'paypalCredit') {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypalCredit);
   } else if (paymentOption === 'applePay') {
-    applePayEnabled = gatewayConfiguration.applePay && Boolean(options.merchantConfiguration.applePayWeb);
+    applePayEnabled = gatewayConfiguration.applePayWeb && Boolean(options.merchantConfiguration.applePay);
     applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
 
     if (!applePayEnabled || !applePayBrowserSupported) { return false; }

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -214,7 +214,7 @@ function isPaymentOptionEnabled(paymentOption, options) {
   } else if (paymentOption === 'paypalCredit') {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypalCredit);
   } else if (paymentOption === 'applePay') {
-    applePayEnabled = gatewayConfiguration.applePay && Boolean(options.merchantConfiguration.applePay);
+    applePayEnabled = gatewayConfiguration.applePay && Boolean(options.merchantConfiguration.applePayWeb);
     applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
 
     if (!applePayEnabled || !applePayBrowserSupported) { return false; }

--- a/test/helpers/fake.js
+++ b/test/helpers/fake.js
@@ -22,7 +22,7 @@ function configuration() {
       creditCards: {
         supportedCardTypes: ['American Express', 'Discover', 'JCB', 'MasterCard', 'Visa']
       },
-      applePay: {}
+      applePayWeb: {}
     },
     analyticsMetadata: {
       sdkVersion: braintreeVersion,


### PR DESCRIPTION
### Summary

Closes #324

We accidentally had the logic set to check for `applePay` instead of `applePayWeb`. This worked because our test merchant had both iOS Apple Pay and web Apple Pay enabled.

Here's the check in the Apple Pay component: https://github.com/braintree/braintree-web/blob/0ae58971df381a59a7aa7b8eca7af378cbbaa19c/src/apple-pay/index.js#L30

### Checklist

- [x] Added a changelog entry
