### PR TITLE
Update checkout.js to v4.0.166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 - Normalize label styles
  - Fixes styling applied by frameworks like Bootstrap
  Fix logic for Apple Pay being enabled (#324)
+- Update checkout.js to v4.0.166
 
 1.9.0
 -----

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,7 +45,7 @@ module.exports = {
   ANALYTICS_REQUEST_TIMEOUT_MS: 2000,
   ANALYTICS_PREFIX: 'web.dropin.',
   CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT: 200,
-  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.4.0.148.min.js',
+  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.4.0.166.min.js',
   INTEGRATION: 'dropin2',
   PAYPAL_CHECKOUT_SCRIPT_ID: 'braintree-dropin-paypal-checkout-script',
   DATA_COLLECTOR_SCRIPT_ID: 'braintree-dropin-data-collector-script',


### PR DESCRIPTION
### Summary

Updates checkout.js to v4.0.166

### Checklist

- [x] Added a changelog entry
