### PR TITLE
Catch Apple Pay exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.9.2
+-----
+- Improve logic for enabling Apple Pay to only trigger with HTTPS
+
 1.9.1
 -----
 - Normalize label styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 CHANGELOG
 =========
 
-1.9.2
------
+unreleased
+----------
 - Improve logic for enabling Apple Pay to only trigger with HTTPS
 
 1.9.1

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -215,7 +215,11 @@ function isPaymentOptionEnabled(paymentOption, options) {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypalCredit);
   } else if (paymentOption === 'applePay') {
     applePayEnabled = gatewayConfiguration.applePayWeb && Boolean(options.merchantConfiguration.applePay);
-    applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
+    try {
+      applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
+    } catch (e) {
+      applePayBrowserSupported = false;
+    }
 
     if (!applePayEnabled || !applePayBrowserSupported) { return false; }
     return true;

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -215,11 +215,7 @@ function isPaymentOptionEnabled(paymentOption, options) {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypalCredit);
   } else if (paymentOption === 'applePay') {
     applePayEnabled = gatewayConfiguration.applePayWeb && Boolean(options.merchantConfiguration.applePay);
-    try {
-      applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
-    } catch (e) {
-      applePayBrowserSupported = false;
-    }
+    applePayBrowserSupported = global.ApplePaySession && global.location.protocol === 'https:' && global.ApplePaySession.canMakePayments();
 
     if (!applePayEnabled || !applePayBrowserSupported) { return false; }
     return true;

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -6,6 +6,7 @@ var constants = require('./constants');
 var paymentMethodTypes = constants.paymentMethodTypes;
 var paymentOptionIDs = constants.paymentOptionIDs;
 var isGuestCheckout = require('./lib/is-guest-checkout');
+var isHTTPS = require('./lib/is-https');
 
 function DropinModel(options) {
   this.componentID = options.componentID;
@@ -215,7 +216,7 @@ function isPaymentOptionEnabled(paymentOption, options) {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypalCredit);
   } else if (paymentOption === 'applePay') {
     applePayEnabled = gatewayConfiguration.applePayWeb && Boolean(options.merchantConfiguration.applePay);
-    applePayBrowserSupported = global.ApplePaySession && global.location.protocol === 'https:' && global.ApplePaySession.canMakePayments();
+    applePayBrowserSupported = global.ApplePaySession && isHTTPS.isHTTPS() && global.ApplePaySession.canMakePayments();
 
     if (!applePayEnabled || !applePayBrowserSupported) { return false; }
     return true;

--- a/src/lib/is-https.js
+++ b/src/lib/is-https.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function isHTTPS() {
+  return global.location.protocol === 'https:';
+}
+
+module.exports = {
+  isHTTPS: isHTTPS
+};

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -179,6 +179,18 @@ describe('DropinModel', function () {
         expect(model.supportedPaymentOptions).to.deep.equal(['card']);
       });
 
+      it('does not support Apple Pay when the page is not loaded over https', function () {
+        var model;
+
+        global.ApplePaySession = this.sandbox.stub().returns({});
+        global.ApplePaySession.canMakePayments = function () { if (global.location.protocol !== 'https:') { throw new Error('Apple Pay not supported without https'); } return true; };
+        this.modelOptions.merchantConfiguration.applePay = true;
+
+        model = new DropinModel(this.modelOptions);
+
+        expect(model.supportedPaymentOptions).to.deep.equal(['card']);
+      });
+
       it('does not support Apple Pay when the device does not support Apple Pay', function () {
         var model;
 


### PR DESCRIPTION
### Summary

This catches an error that might happen when checking Apple Pay availablity. For example in development the ApplePaySession API might throw (InvalidAccessError (DOM Exception 15): Trying to call an ApplePaySession API from an insecure document) because the dropin is embedded in a non-https webpage (localhost).

### Checklist

- [x] Added a changelog entry
