### PR TITLE
Fix for error when retrieving last two digits on saved Apple Pay payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Improve logic for enabling Apple Pay to only trigger with HTTPS (#328 thanks @maxsz)
-- Fix error for saved ApplePay payment method (#332 thanks @julka)
+- Fix error for saved ApplePay payment method (#330 thanks @julka)
 
 1.9.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.9.2
+-----
+- Fix error for saved ApplePay payment method
+
 1.9.1
 -----
 - Normalize label styles

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -46,7 +46,11 @@ PaymentMethodView.prototype._initialize = function () {
         .replace(/@SUBTITLE/g, this.strings.PayPal);
       break;
     case paymentMethodTypes.applePay:
-      lastTwo = this.paymentMethod.details.lastTwo;
+      if (typeof this.paymentMethod.details.paymentInstrumentName === 'string') {
+        lastTwo = this.paymentMethod.details.paymentInstrumentName.slice(-2);
+      } else {
+        lastTwo = this.paymentMethod.details.lastTwo;
+      }
       endingInText = this.strings.endingIn.replace('{{lastTwoCardDigits}}', lastTwo);
       html = html.replace(/@ICON/g, 'logoApplePay')
         .replace(/@CLASSNAME/g, '')

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -46,7 +46,7 @@ PaymentMethodView.prototype._initialize = function () {
         .replace(/@SUBTITLE/g, this.strings.PayPal);
       break;
     case paymentMethodTypes.applePay:
-      lastTwo = this.paymentMethod.details.paymentInstrumentName.slice(-2);
+      lastTwo = this.paymentMethod.details.lastTwo;
       endingInText = this.strings.endingIn.replace('{{lastTwoCardDigits}}', lastTwo);
       html = html.replace(/@ICON/g, 'logoApplePay')
         .replace(/@CLASSNAME/g, '')

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -84,14 +84,13 @@ describe('PaymentMethodView', function () {
       expect(iconContainer.classList.contains('braintree-method__logo@CLASSNAME')).to.be.false;
     });
 
-    it('sets the inner HTML correctly when the paymentMethod is a card from Apple Pay', function () {
+    it('sets the inner HTML correctly when the paymentMethod is a new card from Apple Pay', function () {
       var iconElement, iconContainer, labelElement;
       var paymentMethod = {
         type: 'ApplePayCard',
         details: {
           cardType: 'Visa',
-          lastFour: '0492',
-          lastTwo: '92'
+          paymentInstrumentName: 'Visa 0492'
         }
       };
 

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -107,6 +107,31 @@ describe('PaymentMethodView', function () {
       expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('Visa');
       expect(iconContainer.classList.contains('braintree-method__logo@CLASSNAME')).to.be.false;
     });
+
+    it('sets the inner HTML correctly when the paymentMethod is a saved card from Apple Pay', function () {
+      var iconElement, iconContainer, labelElement;
+      var paymentMethod = {
+        type: 'ApplePayCard',
+        details: {
+          cardType: 'Visa',
+          lastFour: '0492',
+          lastTwo: '92'
+        }
+      };
+
+      this.context.paymentMethod = paymentMethod;
+
+      PaymentMethodView.prototype._initialize.call(this.context);
+
+      iconElement = this.context.element.querySelector('.braintree-method__logo use');
+      iconContainer = this.context.element.querySelector('.braintree-method__logo svg');
+      labelElement = this.context.element.querySelector('.braintree-method__label');
+
+      expect(iconElement.getAttribute('xlink:href')).to.equal('#logoApplePay');
+      expect(labelElement.textContent).to.contain('Ending in ••92');
+      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('Visa');
+      expect(iconContainer.classList.contains('braintree-method__logo@CLASSNAME')).to.be.false;
+    });
   });
 
   describe('setActive', function () {

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -90,7 +90,8 @@ describe('PaymentMethodView', function () {
         type: 'ApplePayCard',
         details: {
           cardType: 'Visa',
-          paymentInstrumentName: 'Visa 0492'
+          lastFour: '0492',
+          lastTwo: '92'
         }
       };
 


### PR DESCRIPTION
### Summary

The `paymentInstrumentName` property isn't available on Apply Pay saved payment methods and trying to slice off the last two characters off undefined creates a JavaScript error. The result fro this is that the dropin payment form does not render for users with saved Apple Pay payment methods (when on a supported device).

Here's the error I'm seeing:

![error](https://user-images.githubusercontent.com/2363679/33105113-96f03316-cef9-11e7-9eca-4a23f9934fea.png)

As you can see here, `this.paymentMethod.details` doesn't have a `paymentInstrumentName` property but it does have a `lastTwo` property. I think that's what you want to use here.

![paymentmethod-object](https://user-images.githubusercontent.com/2363679/33105140-c31dea50-cef9-11e7-93f8-80f2b5c6cfab.png)


### Checklist

- [x] Added a changelog entry
