### PR TITLE
Shows Apple Pay on the small label for saved payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.9.2
+-----
+- Displays "Apple Pay" instead of "undefined" for saved Apple Pay payment methods
+
 1.9.1
 -----
 - Normalize label styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Improve logic for enabling Apple Pay to only trigger with HTTPS (#328 thanks @maxsz)
-- Displays "Apple Pay" instead of "undefined" for saved Apple Pay payment methods (#330 thanks @julka)
+- Displays "Apple Pay" instead of "undefined" for saved Apple Pay payment methods (#332 thanks @julka)
 
 1.9.1
 -----

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -51,7 +51,7 @@ PaymentMethodView.prototype._initialize = function () {
       html = html.replace(/@ICON/g, 'logoApplePay')
         .replace(/@CLASSNAME/g, '')
         .replace(/@TITLE/g, endingInText)
-        .replace(/@SUBTITLE/g, this.strings[this.paymentMethod.details.cardType]);
+        .replace(/@SUBTITLE/g, this.strings['Apple Pay']);
       break;
     default:
       break;

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -90,8 +90,7 @@ describe('PaymentMethodView', function () {
         type: 'ApplePayCard',
         details: {
           cardType: 'Apple Pay - Visa',
-          lastFour: '0492',
-          lastTwo: '92'
+          paymentInstrumentName: 'Visa 0492'
         }
       };
 

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -89,8 +89,9 @@ describe('PaymentMethodView', function () {
       var paymentMethod = {
         type: 'ApplePayCard',
         details: {
-          cardType: 'Visa',
-          paymentInstrumentName: 'Visa 0492'
+          cardType: 'Apple Pay - Visa',
+          lastFour: '0492',
+          lastTwo: '92'
         }
       };
 

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -105,7 +105,7 @@ describe('PaymentMethodView', function () {
 
       expect(iconElement.getAttribute('xlink:href')).to.equal('#logoApplePay');
       expect(labelElement.textContent).to.contain('Ending in ••92');
-      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('Visa');
+      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('Apple Pay');
       expect(iconContainer.classList.contains('braintree-method__logo@CLASSNAME')).to.be.false;
     });
   });


### PR DESCRIPTION
### Summary

This code expects the Apple Pay saved payment method's `cardType` property to look something like `"Visa"` or `"Mastercard"` and thus match a string in one of your localization files, like here: https://github.com/braintree/braintree-web-drop-in/blob/master/src/translations/en_US.js#L49

The value in `cardType` actually looks like `"Apple Pay - Visa"` which is not defined in the localization files.

Here you can see the `cardType` property in `this.paymentMethod.details`:
![paymentmethod-object](https://user-images.githubusercontent.com/2363679/33105456-2b064de6-cefb-11e7-9050-145f56d2bad5.png)

In this pull request I change this over to match the PayPal implementation, which hard codes to the property in the localization object for this payment method. 

And alternative fix would be to change this further upstream so that `cardType` for Apply Pay looks more like what it does with a standard credit card payment `cardType`.

### Checklist

- [x] Added a changelog entry
