### PR TITLE
Update checkout.js to use evergreen link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+==========
+- Update checkout.js to evergreen link
+
 1.9.2
 -----
 - Improve logic for enabling Apple Pay to only trigger with HTTPS (#328 thanks @maxsz)

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,7 +45,7 @@ module.exports = {
   ANALYTICS_REQUEST_TIMEOUT_MS: 2000,
   ANALYTICS_PREFIX: 'web.dropin.',
   CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT: 200,
-  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.4.0.166.min.js',
+  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.js',
   INTEGRATION: 'dropin2',
   PAYPAL_CHECKOUT_SCRIPT_ID: 'braintree-dropin-paypal-checkout-script',
   DATA_COLLECTOR_SCRIPT_ID: 'braintree-dropin-data-collector-script',

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,7 +45,7 @@ module.exports = {
   ANALYTICS_REQUEST_TIMEOUT_MS: 2000,
   ANALYTICS_PREFIX: 'web.dropin.',
   CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT: 200,
-  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.js',
+  CHECKOUT_JS_SOURCE: 'https://www.paypalobjects.com/api/checkout.min.js',
   INTEGRATION: 'dropin2',
   PAYPAL_CHECKOUT_SCRIPT_ID: 'braintree-dropin-paypal-checkout-script',
   DATA_COLLECTOR_SCRIPT_ID: 'braintree-dropin-data-collector-script',


### PR DESCRIPTION
### Summary

Set checkout.js to use the hotlinked version. This _should_ allow security and bug fixes for PP to be pushed automatically.

### Checklist

- [x] Added a changelog entry
