### PR TITLE
3ds fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ==========
 - Update checkout.js to evergreen link
+- Fix issue where 3DS modal would not close when no bank frame is added (#335)
 
 1.9.2
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ==========
 - Update checkout.js to evergreen link
 - Fix issue where 3DS modal would not close when no bank frame is added (#335)
+- Fix issue where liability shift information was only passed back if `liabilityShiftPossible` was true
 
 1.9.2
 -----

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -767,7 +767,7 @@ function formatPaymentMethodPayload(paymentMethod) {
     formattedPaymentMethod.description = paymentMethod.description;
   }
 
-  if (paymentMethod.liabilityShiftPossible) {
+  if (typeof paymentMethod.liabilityShiftPossible === 'boolean') {
     formattedPaymentMethod.liabilityShifted = paymentMethod.liabilityShifted;
     formattedPaymentMethod.liabilityShiftPossible = paymentMethod.liabilityShiftPossible;
   }

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -55,8 +55,12 @@ ThreeDSecure.prototype.verify = function (nonce) {
       return payload;
     })
   ]).then(function (result) {
+    self._cleanupModal();
+
     return result[1];
   }).catch(function (err) {
+    self._cleanupModal();
+
     if (err.type === 'THREE_D_SECURE_CANCELLED') {
       return Promise.resolve(err.payload);
     }
@@ -77,11 +81,12 @@ ThreeDSecure.prototype.cancel = function () {
         liabilityShiftPossible: payload.liabilityShiftPossible
       }
     });
-    self._cleanupModal();
-  }).catch(function () {
+  }).catch(function (err) {
     // only reason this would reject
     // is if there is no verification in progress
     // so we just swallow the error
+  }).then(function () {
+    self._cleanupModal();
   });
 };
 
@@ -99,9 +104,13 @@ ThreeDSecure.prototype._cleanupModal = function () {
   classlist.remove(this._modal.querySelector('.braintree-three-d-secure__modal'), 'braintree-three-d-secure__frame_visible');
   classlist.remove(this._modal.querySelector('.braintree-three-d-secure__backdrop'), 'braintree-three-d-secure__frame_visible');
 
-  iframe.parentNode.removeChild(iframe);
+  if (iframe && iframe.parentNode) {
+    iframe.parentNode.removeChild(iframe);
+  }
   setTimeout(function () {
-    this._modal.parentNode.removeChild(this._modal);
+    if (this._modal.parentNode) {
+      this._modal.parentNode.removeChild(this._modal);
+    }
   }.bind(this), 300);
 };
 

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -81,7 +81,7 @@ ThreeDSecure.prototype.cancel = function () {
         liabilityShiftPossible: payload.liabilityShiftPossible
       }
     });
-  }).catch(function (err) {
+  }).catch(function () {
     // only reason this would reject
     // is if there is no verification in progress
     // so we just swallow the error

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -169,6 +169,12 @@
       config = Object.assign({}, defaultCreateObject, config);
     }
 
+    if (config.threeDSecure === true) {
+      config.threeDSecure = {
+        amount: '10.00'
+      }
+    }
+
     return config;
   }
 

--- a/test/unit/lib/three-d-secure.js
+++ b/test/unit/lib/three-d-secure.js
@@ -224,7 +224,7 @@ describe('ThreeDSecure', function () {
 
       return this.tds.cancel().then(function () {
         expect(this.tds._rejectThreeDSecure).to.not.be.called;
-        expect(this.tds._cleanupModal).to.not.be.called;
+        expect(this.tds._cleanupModal).to.be.calledOnce;
       }.bind(this));
     });
   });


### PR DESCRIPTION
### Summary

If the liability shift is such that an iframe never gets added, the modal never closes. This fixes that issue.

In addition, fixed an issue where request payment method would not return the liability shift information unless liability shift was possible.

Closes #335

### Checklist

- [x] Added a changelog entry
