### PR TITLE
Update braintree-web to v3.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ==========
 - Update checkout.js to evergreen link
+- Update braintree-web to v3.27.0
 - Fix documentation for `preselectVaultedPaymentMethod`
 
 1.9.2

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.26.0",
+    "braintree-web": "3.27.0",
     "@braintree/browser-detection": "1.7.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary

Updates bt-web to v3.27.0

### Checklist

- [x] Added a changelog entry
