### PR TITLE
Fix issue where vaulted apple pay methods were being displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ unreleased
 - Fix documentation for `preselectVaultedPaymentMethod`
 - Fix issue where 3DS modal would not close when no bank frame is added (#335)
 - Fix issue where liability shift information was only passed back if `liabilityShiftPossible` was true
+- Fix issue where vaulted Apple Pay methods were being displayed when they could not be used for transactions
 
 1.9.2
 -----

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -8,6 +8,10 @@ var paymentOptionIDs = constants.paymentOptionIDs;
 var isGuestCheckout = require('./lib/is-guest-checkout');
 var isHTTPS = require('./lib/is-https');
 
+var VAULTED_PAYMENT_METHOD_TYPES_THAT_SHOULD_BE_HIDDEN = [
+  'ApplePayCard'
+];
+
 function DropinModel(options) {
   this.componentID = options.componentID;
   this.merchantConfiguration = options.merchantConfiguration;
@@ -168,7 +172,7 @@ DropinModel.prototype._getSupportedPaymentMethods = function (paymentMethods) {
   var supportedPaymentMethods = this.supportedPaymentOptions.reduce(function (array, key) {
     var paymentMethodType = paymentMethodTypes[key];
 
-    if (paymentMethodType) {
+    if (canShowVaultedPaymentMethodType(paymentMethodType)) {
       array.push(paymentMethodType);
     }
 
@@ -221,6 +225,10 @@ function isPaymentOptionEnabled(paymentOption, options) {
     return applePayEnabled && applePayBrowserSupported;
   }
   throw new DropinError('paymentOptionPriority: Invalid payment option specified.');
+}
+
+function canShowVaultedPaymentMethodType(paymentMethodType) {
+  return paymentMethodType && VAULTED_PAYMENT_METHOD_TYPES_THAT_SHOULD_BE_HIDDEN.indexOf(paymentMethodType) === -1;
 }
 
 module.exports = DropinModel;

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -18,7 +18,7 @@ PaymentMethodView.prototype = Object.create(BaseView.prototype);
 PaymentMethodView.prototype.constructor = PaymentMethodView;
 
 PaymentMethodView.prototype._initialize = function () {
-  var endingInText, lastTwo;
+  var endingInText;
   var html = paymentMethodHTML;
   var paymentMethodCardTypes = constants.paymentMethodCardTypes;
   var paymentMethodTypes = constants.paymentMethodTypes;
@@ -46,12 +46,10 @@ PaymentMethodView.prototype._initialize = function () {
         .replace(/@SUBTITLE/g, this.strings.PayPal);
       break;
     case paymentMethodTypes.applePay:
-      lastTwo = this.paymentMethod.details.dpanLastTwo || this.paymentMethod.details.lastTwo;
-      endingInText = this.strings.endingIn.replace('{{lastTwoCardDigits}}', lastTwo);
       html = html.replace(/@ICON/g, 'logoApplePay')
         .replace(/@CLASSNAME/g, '')
-        .replace(/@TITLE/g, endingInText)
-        .replace(/@SUBTITLE/g, this.strings['Apple Pay']);
+        .replace(/@TITLE/g, this.strings['Apple Pay'])
+        .replace(/@SUBTITLE/g, '');
       break;
     default:
       break;

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -9,11 +9,22 @@ var hostedFields = require('braintree-web/hosted-fields');
 var paypalCheckout = require('braintree-web/paypal-checkout');
 var threeDSecure = require('braintree-web/three-d-secure');
 var ThreeDSecure = require('../../src/lib/three-d-secure');
+var Promise = require('../../src/lib/promise');
 var CardView = require('../../src/views/payment-sheet-views/card-view');
 var constants = require('../../src/constants');
 var checkoutJsSource = constants.CHECKOUT_JS_SOURCE;
 var braintreeWebVersion = require('../../package.json').dependencies['braintree-web'];
 var DEFAULT_CHECKOUTJS_LOG_LEVEL = 'warn';
+
+function delay(amount) {
+  amount = amount || 10;
+
+  return new Promise(function (resolve) {
+    setTimeout(function () {
+      resolve();
+    }, amount);
+  });
+}
 
 describe('Dropin', function () {
   beforeEach(function () {
@@ -180,11 +191,11 @@ describe('Dropin', function () {
       instance._initialize(function () {
         var paypalOption = this.container.querySelector('.braintree-option__paypal');
 
-        setTimeout(function () {
+        delay().then(function () {
           expect(paypalOption.className).to.include('braintree-disabled');
           expect(paypalOption.innerHTML).to.include(constants.errors.PAYPAL_NON_LINKED_SANDBOX);
           done();
-        }, 100);
+        });
       }.bind(this));
     });
 
@@ -352,7 +363,7 @@ describe('Dropin', function () {
           gatewayConfiguration: fake.configuration().gatewayConfiguration
         };
       };
-      this.client.request.yields(null, paymentMethodsPayload);
+      this.client.request.resolves(paymentMethodsPayload);
 
       this.sandbox.stub(analytics, 'sendEvent');
 
@@ -366,7 +377,7 @@ describe('Dropin', function () {
           data: {
             defaultFirst: 1
           }
-        }), this.sandbox.match.func);
+        }));
 
         done();
       }.bind(this));
@@ -394,7 +405,7 @@ describe('Dropin', function () {
           gatewayConfiguration: fake.configuration().gatewayConfiguration
         };
       };
-      this.client.request.yields(new Error('This failed'));
+      this.client.request.rejects(new Error('This failed'));
 
       this.sandbox.stub(analytics, 'sendEvent');
 
@@ -425,7 +436,7 @@ describe('Dropin', function () {
           gatewayConfiguration: fake.configuration().gatewayConfiguration
         };
       };
-      this.client.request.yields(null, paymentMethodsPayload);
+      this.client.request.resolves(paymentMethodsPayload);
 
       this.sandbox.stub(analytics, 'sendEvent');
 
@@ -454,7 +465,7 @@ describe('Dropin', function () {
           gatewayConfiguration: fake.configuration().gatewayConfiguration
         };
       };
-      this.client.request.yields(null, paymentMethodsPayload);
+      this.client.request.resolves(paymentMethodsPayload);
 
       this.sandbox.stub(analytics, 'sendEvent');
 
@@ -569,7 +580,9 @@ describe('Dropin', function () {
         done();
       });
 
-      instance._model._emit('asyncDependenciesReady');
+      delay().then(function () {
+        instance._model._emit('asyncDependenciesReady');
+      });
     });
 
     it('sends web.dropin.appeared event when async dependencies are ready', function (done) {
@@ -585,8 +598,10 @@ describe('Dropin', function () {
         done();
       });
 
-      instance._model.dependencySuccessCount = 2;
-      instance._model._emit('asyncDependenciesReady');
+      delay().then(function () {
+        instance._model.dependencySuccessCount = 2;
+        instance._model._emit('asyncDependenciesReady');
+      });
     });
 
     it('loads strings by default', function (done) {

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -104,8 +104,8 @@ describe('PaymentMethodView', function () {
       labelElement = this.context.element.querySelector('.braintree-method__label');
 
       expect(iconElement.getAttribute('xlink:href')).to.equal('#logoApplePay');
-      expect(labelElement.textContent).to.contain('Ending in ••92');
-      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('Apple Pay');
+      expect(labelElement.textContent).to.contain('Apple Pay');
+      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('');
       expect(iconContainer.classList.contains('braintree-method__logo@CLASSNAME')).to.be.false;
     });
 
@@ -125,8 +125,8 @@ describe('PaymentMethodView', function () {
 
       labelElement = this.context.element.querySelector('.braintree-method__label');
 
-      expect(labelElement.textContent).to.contain('Ending in ••92');
-      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('Apple Pay');
+      expect(labelElement.textContent).to.contain('Apple Pay');
+      expect(labelElement.querySelector('.braintree-method__label--small').textContent).to.equal('');
     });
   });
 


### PR DESCRIPTION
### Summary

Even if a vaulted apple pay method is presented on the client, it can't be used to run a transaction. This PR removes the vaulted apple pay methods from appearing as a choice for the customer and fixes a display issue where the wrong `ending in` text was being shown. Since there is no need to differentiate the Apple Pay method anymore, since it can't be vaulted, I've elected to include no text.

### Checklist

- [x] Added a changelog entry
