### PR TITLE
Update braintree-web to v3.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ==========
 - Update checkout.js to evergreen link
 - Update braintree-web to v3.28.0
+- Update promise-polyfill to v7.0.0
 - Fix documentation for `preselectVaultedPaymentMethod`
 - Fix issue where 3DS modal would not close when no bank frame is added (#335)
 - Fix issue where liability shift information was only passed back if `liabilityShiftPossible` was true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 unreleased
 ==========
 - Update checkout.js to evergreen link
-- Update braintree-web to v3.27.0
+- Update braintree-web to v3.28.0
 - Fix documentation for `preselectVaultedPaymentMethod`
 - Fix issue where 3DS modal would not close when no bank frame is added (#335)
 - Fix issue where liability shift information was only passed back if `liabilityShiftPossible` was true

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "braintree-web": "3.28.0",
     "@braintree/browser-detection": "1.7.0",
-    "promise-polyfill": "6.0.2",
+    "promise-polyfill": "7.0.0",
     "@braintree/wrap-promise": "1.1.1"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.27.0",
+    "braintree-web": "3.28.0",
     "@braintree/browser-detection": "1.7.0",
     "promise-polyfill": "6.0.2",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary
Update bt-web dependency to v3.28.0

### Checklist

- [x] Added a changelog entry
