### PR TITLE
Update braintree-web to version 3.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Update braintree-web to v3.28.1
+
 1.9.3
 -----
 - Update checkout.js to evergreen link

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.28.0",
+    "braintree-web": "3.28.1",
     "@braintree/browser-detection": "1.7.0",
     "promise-polyfill": "7.0.0",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary

Update bt-web to v3.28.1

### Checklist

- [x] Added a changelog entry
