### PR TITLE
Update braintree-web to v3.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 unreleased
 ----------
-- Update braintree-web to v3.28.1
+- Update braintree-web to v3.29.0
 - Update jsdoc-template to v3.2.0
 
 1.9.3

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "1.1.0"
   },
   "dependencies": {
-    "braintree-web": "3.28.1",
+    "braintree-web": "3.29.0",
     "@braintree/browser-detection": "1.7.0",
     "promise-polyfill": "7.0.0",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary

Updates braintree-web to v3.29.0

### Checklist

- [x] Added a changelog entry
