### PR TITLE
Fix issue where 3DS modal would not appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Update braintree-web to v3.29.0
 - Update jsdoc-template to v3.2.0
+- Fix issue where 3DS modal would not appear (#352)
 
 1.9.3
 -----

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -33,15 +33,10 @@ ThreeDSecure.prototype.verify = function (nonce) {
       amount: this._config.amount,
       showLoader: false,
       addFrame: function (err, iframe) {
-        var count = 0;
         var modalBody = self._modal.querySelector('.braintree-three-d-secure__modal-body');
 
         iframe.onload = function () {
-          count++;
-
-          if (count === 2) {
-            classlist.add(modalBody, 'braintree-three-d-secure__frame-active');
-          }
+          classlist.add(modalBody, 'braintree-three-d-secure__frame-active');
         };
 
         modalBody.appendChild(iframe);


### PR DESCRIPTION
Closes #352

### Summary

We added this `iframe.onload` check to make the animation smoother for the bank frame to appear, but it looks like there are some cases where a second `onload` event does not fire.

### Checklist

- [x] Added a changelog entry
