### PR TITLE
Fix atob polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - Use generic error with console log when a payment method fails to set up
 - Fix issue where Mastercard was displayed as MasterCard
 - Allow card form to not be cleared after succesful tokenization with `card.clearFieldsAfterTokenization`
+- Fix atob polyfill
 
 1.10.0
 ------

--- a/src/lib/polyfill.js
+++ b/src/lib/polyfill.js
@@ -30,6 +30,8 @@ function atob(base64String) {
 }
 
 module.exports = {
-  atob: atobNormalized,
+  atob: function (base64String) {
+    return atobNormalized.call(global, base64String);
+  },
   _atob: atob
 };


### PR DESCRIPTION
### Summary
Closes #382

I think the real fix here is to move the logic about whether a client token includes a customer id to the client component, so that braintree-web-drop-in doesn't need to polyfill atob, but this is a good stop gap.

### Checklist

- [x] Added a changelog entry
