### PR TITLE
Fix issue where drop-in would fail to load if ext script is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - Use generic error with console log when a payment method fails to set up
 - Fix issue where Mastercard was displayed as MasterCard
 - Allow card form to not be cleared after succesful tokenization with `card.clearFieldsAfterTokenization`
+- Fix issue where Drop-in would fail to load if something blockd an external script from loading (#379)
 
 1.10.0
 ------

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -258,6 +258,8 @@ function isPaymentOptionEnabled(paymentOption, options) {
   return SheetView.isEnabled({
     client: options.client,
     merchantConfiguration: options.merchantConfiguration
+  }).catch(function () {
+    return Promise.resolve(false);
   });
 }
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -123,6 +123,11 @@
       flow: 'checkout',
       amount: '10.00',
       currency: 'USD'
+    },
+    googlePay: {
+      totalPriceStatus: 'FINAL',
+      totalPrice: '10.00',
+      currencyCode: 'USD'
     }
   };
   var dropinInstance;


### PR DESCRIPTION
closes #379

### Summary

Basically, if an external script (such as the Google Pay wrapper) fails to load, Drop-in was just spinning and spinner. This adds a check and resolves the payment method as not being enabled if there is an error in the check for whether or not it is enabled.

### Checklist

- [x] Added a changelog entry