### PR TITLE
Fix issue where Drop-in would throw if another google script was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ unreleased
 - Update braintree-web to v3.32.1
 - Fix issue where Drop-in would fail to load if something blocked an external script from loading (#379)
 - Report error for duplicate payment method error
+- Fix issue where Drop-in would throw an error if another Google script was included on the page
 
 1.10.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ unreleased
 - Update braintree-web to v3.32.1
 - Fix issue where Drop-in would fail to load if something blocked an external script from loading (#379)
 - Report error for duplicate payment method error
-- Fix issue where Drop-in would throw an error if another Google script was included on the page
+- Fix issue where Drop-in would throw an error if another Google script was included on the merchant page
+- Fix issue where Drop-in would throw an error if a non-checkout.js PayPal script was included in the merchant page
 
 1.10.0
 ------

--- a/src/lib/create-from-script-tag.js
+++ b/src/lib/create-from-script-tag.js
@@ -23,10 +23,12 @@ var WHITELISTED_DATA_ATTRIBUTES = [
   'paypal.amount',
   'paypal.currency',
   'paypal.flow',
+  'paypal.landing-page-type',
 
   'paypal-credit.amount',
   'paypal-credit.currency',
-  'paypal-credit.flow'
+  'paypal-credit.flow',
+  'paypal-credit.landing-page-type'
 ];
 
 function injectHiddenInput(name, value, form) {

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -109,7 +109,7 @@ BasePayPalView.isEnabled = function (options) {
     return Promise.resolve(false);
   }
 
-  if (!(global.paypal && global.paypal.Button)) {
+  if (global.paypal && global.paypal.Button) {
     return Promise.resolve(true);
   }
 

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -109,7 +109,7 @@ BasePayPalView.isEnabled = function (options) {
     return Promise.resolve(false);
   }
 
-  if (global.paypal) {
+  if (!(global.paypal && global.paypal.Button)) {
     return Promise.resolve(true);
   }
 

--- a/src/views/payment-sheet-views/google-pay-view.js
+++ b/src/views/payment-sheet-views/google-pay-view.js
@@ -89,7 +89,7 @@ GooglePayView.isEnabled = function (options) {
   }
 
   return Promise.resolve().then(function () {
-    if (!global.google) {
+    if (!(global.google && global.google.payments && global.google.payments.api && global.google.payments.api.PaymentsClient)) {
       return assets.loadScript({
         id: constants.GOOGLE_PAYMENT_SCRIPT_ID,
         src: constants.GOOGLE_PAYMENT_SOURCE

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -117,12 +117,14 @@
     paypal: {
       flow: 'checkout',
       amount: '10.00', // be sure to validate this amount on your server
-      currency: 'USD'
+      currency: 'USD',
+      landingPageType: 'login' // hard code this so we get a consistent experience for e2e tests
     },
     paypalCredit: {
       flow: 'checkout',
       amount: '10.00',
-      currency: 'USD'
+      currency: 'USD',
+      landingPageType: 'login' // hard code this so we get a consistent experience for e2e tests
     },
     googlePay: {
       totalPriceStatus: 'FINAL',

--- a/test/app/promise.html
+++ b/test/app/promise.html
@@ -111,12 +111,14 @@
     paypal: {
       flow: 'checkout',
       amount: '10.00', // be sure to validate this amount on your server
-      currency: 'USD'
+      currency: 'USD',
+      landingPageType: 'login' // hard code this so we get a consistent experience for e2e tests
     },
     paypalCredit: {
       flow: 'checkout',
       amount: '10.00',
-      currency: 'USD'
+      currency: 'USD',
+      landingPageType: 'login' // hard code this so we get a consistent experience for e2e tests
     }
   };
   var dropinInstance;

--- a/test/app/script-tag-integration.html
+++ b/test/app/script-tag-integration.html
@@ -46,7 +46,9 @@
    data-paypal.flow="checkout"
    data-paypal.amount="10.00"
    data-paypal.currency="USD"
+   data-paypal.landing-page-type="login"
    data-paypal-credit.flow="vault"
+   data-paypal-credit.landing-page-type="login"
   ></script>
   <input id="pay-button" type="submit" value="Pay">
 </form>

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -782,7 +782,9 @@ describe('BasePayPalView', function () {
       };
 
       this.configuration.gatewayConfiguration.paypalEnabled = true;
-      global.paypal = {};
+      global.paypal = {
+        Button: {}
+      };
 
       this.sandbox.stub(assets, 'loadScript').resolves();
     });

--- a/test/unit/views/payment-sheet-views/google-pay-view.js
+++ b/test/unit/views/payment-sheet-views/google-pay-view.js
@@ -435,6 +435,31 @@ describe('GooglePayView', function () {
       });
     });
 
+    it('loads Google Payment script file when the payment client on google global does not exist', function () {
+      var storedFakeGoogle = global.google;
+
+      delete global.google;
+      global.google = {
+        payments: {
+          api: {}
+        }
+      };
+
+      assets.loadScript.callsFake(function () {
+        global.google = storedFakeGoogle;
+
+        return Promise.resolve();
+      });
+
+      return GooglePayView.isEnabled(this.fakeOptions).then(function () {
+        expect(assets.loadScript).to.be.calledOnce;
+        expect(assets.loadScript).to.be.calledWith({
+          id: 'braintree-dropin-google-payment-script',
+          src: 'https://payments.developers.google.com/js/apis/pay.js'
+        });
+      });
+    });
+
     it('does not load Google Payment script file if global google pay object already exists', function () {
       return GooglePayView.isEnabled(this.fakeOptions).then(function () {
         expect(assets.loadScript).to.not.be.called;


### PR DESCRIPTION
### Summary

We were only checking on the presence of `global.google` when determining if we should skip loading the script. Needed to check for specific values on it instead.

### Checklist

- [x] Added a changelog entry
