### PR TITLE
Fix issue where sass compliation would prevent styling of ApplePay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Fix issue where sass compliation would prevent styling of ApplePay button
+
 1.11.0
 ------
 - Use generic error with console log when a payment method fails to set up

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -360,15 +360,6 @@ $loader-scale-duration: 300ms;
         display: inline-block;
         -webkit-appearance: -apple-pay-button;
     }
-    .apple-pay-button-black {
-        -apple-pay-button-style: black;
-    }
-    .apple-pay-button-white {
-        -apple-pay-button-style: white;
-    }
-    .apple-pay-button-white-outline {
-        -apple-pay-button-style: white-outline;
-    }
 }
 @supports not (-webkit-appearance: -apple-pay-button) {
     .apple-pay-button {

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -41,7 +41,7 @@ ApplePayView.prototype.initialize = function () {
     });
 
     buttonDiv.onclick = self._showPaymentSheet.bind(self);
-    buttonDiv.classList.add('apple-pay-button-' + (self.model.merchantConfiguration.applePay.buttonStyle || 'black'));
+    buttonDiv.style['-apple-pay-button-style'] = self.model.merchantConfiguration.applePay.buttonStyle || 'black';
 
     self.model.asyncDependencyReady();
   }).catch(function (err) {

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -144,7 +144,7 @@ describe('ApplePayView', function () {
       return this.view.initialize().then(function () {
         var button = document.querySelector('[data-braintree-id="apple-pay-button"]');
 
-        expect(button.classList.contains('apple-pay-button-black')).to.be.true;
+        expect(button.style['-apple-pay-button-style']).to.equal('black');
       });
     });
 
@@ -154,7 +154,7 @@ describe('ApplePayView', function () {
       return this.view.initialize().then(function () {
         var button = document.querySelector('[data-braintree-id="apple-pay-button"]');
 
-        expect(button.classList.contains('apple-pay-button-white')).to.be.true;
+        expect(button.style['-apple-pay-button-style']).to.equal('white');
       });
     });
 


### PR DESCRIPTION
### Summary

Sass was converting `black` to `#000` which is invalid for Apple Pay buttons.

### Checklist

- [x] Added a changelog entry
