### PR TITLE
 fix order of nested closing tags in expiration date html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Fix issue where sass compliation would prevent styling of ApplePay button
+- Fix slight HTML error for the expiration date field
 
 1.11.0
 ------

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -167,10 +167,10 @@
                     </div>
                   </div>
                 </div>
-
-                <div data-braintree-id="expiration-date-field-error" class="braintree-form__field-error"></div>
-              </div>
-            </label>
+              </label>
+              <div data-braintree-id="expiration-date-field-error" class="braintree-form__field-error"></div>
+            </div>
+            
 
             <div data-braintree-id="cvv-field-group" class="braintree-form__field-group">
               <label>


### PR DESCRIPTION
### Summary
The HTML tags are in slightly the wrong order, meaning that the error message for the expiration date is inside of the label whereas all of the others are outside. This means that the styling can end up being inconsistent.

#### Before:
![screen shot 2018-07-05 at 12 54 32](https://user-images.githubusercontent.com/22368483/42322244-a2fde750-8053-11e8-8abb-5de79649fc3b.png)

#### After:
![screen shot 2018-07-05 at 13 09 15](https://user-images.githubusercontent.com/22368483/42322517-bff0a680-8054-11e8-95e9-60746d4e3975.png)

### Checklist

- [x] Added a changelog entry
