### PR TITLE
Drop-in would throw undefined error when updating payment method configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Provide browserified version of Drop-in on npm at `dist/browser/dropin.js`
+- Fix issue where Drop-in would throw an error when updating not presented payment method
 
 1.12.0
 ------

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -371,7 +371,7 @@ Dropin.prototype._initialize = function (callback) {
  * dropinInstance.updateConfiguration('paypal', 'amount', '10.00');
  */
 Dropin.prototype.updateConfiguration = function (property, key, value) {
-  var view = this._mainView.getView(property);
+  var view;
 
   if (UPDATABLE_CONFIGURATION_OPTIONS.indexOf(property) === -1) {
     return;
@@ -384,6 +384,8 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
 
     return;
   }
+
+  view = this._mainView.getView(property);
 
   if (!view) {
     return;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -371,6 +371,8 @@ Dropin.prototype._initialize = function (callback) {
  * dropinInstance.updateConfiguration('paypal', 'amount', '10.00');
  */
 Dropin.prototype.updateConfiguration = function (property, key, value) {
+  var view = this._mainView.getView(property);
+
   if (UPDATABLE_CONFIGURATION_OPTIONS.indexOf(property) === -1) {
     return;
   }
@@ -382,8 +384,6 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
 
     return;
   }
-
-  var view = this._mainView.getView(property);
 
   if (!view) {
     return;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -383,6 +383,10 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
     return;
   }
 
+  if (this._mainView.getView(property) === undefined) {
+    return;
+  }
+
   this._mainView.getView(property).updateConfiguration(key, value);
 
   if (UPDATABLE_CONFIGURATION_OPTIONS_THAT_REQUIRE_UNVAULTED_PAYMENT_METHODS_TO_BE_REMOVED.indexOf(property) === -1) {

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -383,11 +383,13 @@ Dropin.prototype.updateConfiguration = function (property, key, value) {
     return;
   }
 
-  if (this._mainView.getView(property) === undefined) {
+  var view = this._mainView.getView(property);
+
+  if (!view) {
     return;
   }
 
-  this._mainView.getView(property).updateConfiguration(key, value);
+  view.updateConfiguration(key, value);
 
   if (UPDATABLE_CONFIGURATION_OPTIONS_THAT_REQUIRE_UNVAULTED_PAYMENT_METHODS_TO_BE_REMOVED.indexOf(property) === -1) {
     return;


### PR DESCRIPTION
### Summary
Fixed issue where undefined error was thrown when payment method is not visible but is set in configuration.

### Checklist

- [x] Added a changelog entry
