### PR TITLE
Fix issue the keyboard could get stuck when entering card details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ unreleased
 ----------
 - Provide browserified version of Drop-in on npm at `dist/browser/dropin.js`
 - Fix issue where Drop-in would throw an error when updating not presented payment method
-- Fix issue the keyboard could get stuck when entering card details (#419)
+- Fix issue where the keyboard could get stuck when entering card details on iOS (#419)
 
 1.12.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Provide browserified version of Drop-in on npm at `dist/browser/dropin.js`
 - Fix issue where Drop-in would throw an error when updating not presented payment method
+- Fix issue the keyboard could get stuck when entering card details (#419)
 
 1.12.0
 ------

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -125,7 +125,7 @@
               <div class="braintree-form__label">{{cardholderNameLabel}}</div>
               <div class="braintree-form__field">
                 <div class="braintree-form-cardholder-name braintree-form__hosted-field">
-                  <input id="braintree__card-view-input__cardholder-name" type="text" placeholder="{{cardholderNamePlaceholder}}"/>
+                  <input class="braintree-form__raw-input" id="braintree__card-view-input__cardholder-name" type="text" placeholder="{{cardholderNamePlaceholder}}"/>
                 </div>
                 <div class="braintree-form__icon-container">
                   <div class="braintree-form__icon braintree-form__field-error-icon">

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -658,7 +658,7 @@ $loader-scale-duration: 300ms;
           border-color: $black-40;
         }
 
-        input {
+        input.braintree-form__raw-input {
           border:none;
           background-image:none;
           background-color:transparent;


### PR DESCRIPTION
closes #419

### Summary

There's a bug that's happening in web drop-in on iOS devices, where if you click on the field, then click out of it, the keyboard persists.

Click the done link and it goes away, but click on any element on the page and it re-appears.

I figured out what was causing it

```css
input {
  border: none;
}
```

But... why is this affecting how the inputs _inside an iframe_ behave?

Best guess here is that it's a combo bug in iOS's safari, where the css is causing the keyboard not to leave on blur for all things on the page _and_ a bug in ios iframe inputs where they don't give up their focus when clicking on an element outside of the frame.

Combine them and it repeatedly brings up the keyboard.

The solution was to specify a class on the input:

```css
input.braintree-form__raw-input {
  // styles
}
```
 
Don't know why that would matter, since it was nested under a ton of classes already:

```css
.braintree-sheet__content--form .braintree-form__field-group .braintree-form__field .braintree-form__hosted-field input {
  // styles
}
```

### Checklist

- [x] Added a changelog entry
