### PR TITLE
Update braintree-web to v3.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ unreleased
 - Provide browserified version of Drop-in on npm at `dist/browser/dropin.js`
 - Fix issue where Drop-in would throw an error when updating not presented payment method
 - Fix issue where the keyboard could get stuck when entering card details on iOS (#419)
+- Update braintree-web to v3.37.0
 
 1.12.0
 ------

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vinyl-source-stream": "2.0.0"
   },
   "dependencies": {
-    "braintree-web": "3.36.0",
+    "braintree-web": "3.37.0",
     "@braintree/browser-detection": "1.7.0",
     "promise-polyfill": "8.0.0",
     "@braintree/wrap-promise": "1.1.1"


### PR DESCRIPTION
### Summary
closes https://github.com/braintree/braintree-web-drop-in/issues/392

### Checklist

- [x] Added a changelog entry
