### PR TITLE
Fix issue where Drop-in would emit requestable events after tokenization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Change Google Pay button to black style to better match [Google's brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines)
 - Allow passing in [button options](https://developers.google.com/pay/api/web/reference/object#ButtonOptions) to Google Pay configuration
+- Fix issue where Drop-in would emit `noPaymentMethodRequestable` and `paymentMethodRequestable` right after tokenization
 
 1.13.0
 ------

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -394,13 +394,13 @@ CardView.prototype.tokenize = function () {
           resolve(payload);
           classlist.remove(self.element, 'braintree-sheet--tokenized');
         }, 0);
-        self._isTokenizing = false;
       };
 
       transitionHelper.onTransitionEnd(self.element, 'max-height', transitionCallback);
 
       setTimeout(function () {
         self.allowUserAction();
+        self._isTokenizing = false;
       }, constants.CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT);
 
       classlist.add(self.element, 'braintree-sheet--tokenized');

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -2219,7 +2219,7 @@ describe('CardView', function () {
         setTimeout(function () {
           expect(this.context._isTokenizing).to.equal(false);
           done();
-        }.bind(this), 100);
+        }.bind(this), 300);
       }.bind(this));
     });
 


### PR DESCRIPTION
### Summary
Fix issue where Drop-in would emit `noPaymentMethodRequestable` and `paymentMethodRequestable` right after tokenization

This was resulting in duplicate nonces getting sent to merchant servers. (if copying our docs for how to implement the event listeners)

### Checklist

- [x] Added a changelog entry
