### PR TITLE
Explicitly opt out of additional PayPal credit button in PayPal view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Explicitly opt out of additional PayPal credit button in normal PayPal view
+
 1.14.0
 ------
 - Change Google Pay button to black style to better match [Google's brand guidelines](https://developers.google.com/pay/api/web/guides/brand-guidelines)

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -76,6 +76,10 @@ BasePayPalView.prototype.initialize = function () {
     if (isCredit) {
       buttonSelector = '[data-braintree-id="paypal-credit-button"]';
       checkoutJSConfiguration.style.label = 'credit';
+    } else {
+      checkoutJSConfiguration.funding = {
+        disallowed: [global.paypal.FUNDING.CREDIT]
+      };
     }
 
     return global.paypal.Button.render(checkoutJSConfiguration, buttonSelector).then(function () {

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -21,7 +21,10 @@ describe('BasePayPalView', function () {
       Button: {
         render: this.sandbox.stub().resolves()
       },
-      setup: this.sandbox.stub()
+      setup: this.sandbox.stub(),
+      FUNDING: {
+        CREDIT: 'credit'
+      }
     };
     this.sandbox.stub(analytics, 'sendEvent');
 
@@ -191,6 +194,30 @@ describe('BasePayPalView', function () {
             label: 'credit'
           }
         });
+      }.bind(this));
+    });
+
+    it('dissallows credit option for PayPal', function () {
+      this.view.model.merchantConfiguration.paypal = this.view.model.merchantConfiguration.paypal;
+      this.view._isPayPalCredit = false;
+
+      return this.view.initialize().then(function () {
+        expect(this.paypal.Button.render).to.be.calledWithMatch({
+          funding: {
+            disallowed: ['credit']
+          }
+        });
+      }.bind(this));
+    });
+
+    it('does not include funding param for PayPal credit', function () {
+      this.view.model.merchantConfiguration.paypalCredit = this.view.model.merchantConfiguration.paypal;
+      this.view._isPayPalCredit = true;
+
+      return this.view.initialize().then(function () {
+        var renderOptions = this.paypal.Button.render.args[0][0];
+
+        expect(renderOptions.funding).to.not.exist;
       }.bind(this));
     });
 


### PR DESCRIPTION
### Summary

PP is starting to show dual buttons for PayPal and PayPal Credit for US customers. This is unacceptable for us, since we explicitly show a second PayPal Credit button.

We can opt out by disabling CREDIT from the funding array.

### Checklist

- [x] Added a changelog entry
