### PR TITLE
Fix issue where 3ds modal may not get cleaned up during teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ unreleased
 - Fix error with `toLowerCase` on error reporting
 - Update braintree-web to v3.42.0
 - Update @braintree/asset-loader to v0.2.1
+- Fix issue where 3ds modal may not get cleaned up during teardown (#463)
 
 1.14.1
 ------

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -90,11 +90,15 @@ ThreeDSecure.prototype.updateConfiguration = function (key, value) {
 };
 
 ThreeDSecure.prototype.teardown = function () {
-  return this._instance.teardown();
+  return Promise.all([
+    this._cleanupModal(),
+    this._instance.teardown()
+  ]);
 };
 
 ThreeDSecure.prototype._cleanupModal = function () {
   var iframe = this._modal.querySelector('iframe');
+  var self = this;
 
   classList.remove(this._modal.querySelector('.braintree-three-d-secure__modal'), 'braintree-three-d-secure__frame_visible');
   classList.remove(this._modal.querySelector('.braintree-three-d-secure__backdrop'), 'braintree-three-d-secure__frame_visible');
@@ -102,11 +106,16 @@ ThreeDSecure.prototype._cleanupModal = function () {
   if (iframe && iframe.parentNode) {
     iframe.parentNode.removeChild(iframe);
   }
-  setTimeout(function () {
-    if (this._modal.parentNode) {
-      this._modal.parentNode.removeChild(this._modal);
-    }
-  }.bind(this), 300);
+
+  return new Promise(function (resolve) {
+    setTimeout(function () {
+      if (self._modal.parentNode) {
+        self._modal.parentNode.removeChild(self._modal);
+      }
+
+      resolve();
+    }, 300);
+  });
 };
 
 ThreeDSecure.prototype._setupModal = function (cardVerificationString) {

--- a/test/unit/lib/three-d-secure.js
+++ b/test/unit/lib/three-d-secure.js
@@ -230,14 +230,23 @@ describe('ThreeDSecure', function () {
   });
 
   describe('teardown', function () {
-    it('calls teardown on 3ds instance', function () {
-      var tds = new ThreeDSecure({}, {}, 'Card Verification');
+    beforeEach(function () {
+      this.tds = new ThreeDSecure({}, {}, 'Card Verification');
 
-      tds._instance = this.threeDSecureInstance;
+      this.tds._instance = this.threeDSecureInstance;
       this.sandbox.stub(this.threeDSecureInstance, 'teardown').resolves();
+      this.sandbox.stub(this.tds, '_cleanupModal').resolves();
+    });
 
-      return tds.teardown().then(function () {
+    it('calls teardown on 3ds instance', function () {
+      return this.tds.teardown().then(function () {
         expect(this.threeDSecureInstance.teardown).to.be.calledOnce;
+      }.bind(this));
+    });
+
+    it('cleanus up modal', function () {
+      return this.tds.teardown().then(function () {
+        expect(this.tds._cleanupModal).to.be.calledOnce;
       }.bind(this));
     });
   });

--- a/test/unit/lib/three-d-secure.js
+++ b/test/unit/lib/three-d-secure.js
@@ -244,7 +244,7 @@ describe('ThreeDSecure', function () {
       }.bind(this));
     });
 
-    it('cleanus up modal', function () {
+    it('cleans up modal', function () {
       return this.tds.teardown().then(function () {
         expect(this.tds._cleanupModal).to.be.calledOnce;
       }.bind(this));


### PR DESCRIPTION
closes #463

### Summary

If teardown is called while 3ds modal is open, the modal doesn't get cleaned up from the DOM.

### Checklist

- [x] Added a changelog entry
