### PR TITLE
Update Google Pay to allow API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ unreleased
 - Update braintree-web to v3.42.0
 - Update @braintree/asset-loader to v0.2.1
 - Fix issue where 3ds modal may not get cleaned up during teardown (#463)
+- Allow easy Google Pay version 2 configuration
 
 1.14.1
 ------

--- a/src/index.js
+++ b/src/index.js
@@ -156,6 +156,7 @@ var VERSION = process.env.npm_package_version;
 /** @typedef {object} googlePayCreateOptions The configuration options for Google Pay. Additional options from the few listed here are available, many have default values applied based on the settings found in the Braintree Gateway. For more information, see [Google's Documentation](https://developers.google.com/pay/api/web/object-reference#request-objects).
  *
  * @param {string} merchantId The ID provided by Google for processing transactions in production. Not necessary for testing in sandbox.
+ * @param {string} [googlePayVersion=1] The version of the Google Pay API to use. Defaults to 1, but 2 can be passed in.
  * @param {external:GooglePayTransactionInfo} transactionInfo The transaction details necessary for processing the payment.
  * @param {external:GooglePayButtonOptions} [button] The button options for configuring the look of the Google Pay button. The `onClick` property cannot be overwritten.
  */

--- a/src/views/payment-sheet-views/google-pay-view.js
+++ b/src/views/payment-sheet-views/google-pay-view.js
@@ -19,9 +19,14 @@ GooglePayView.ID = GooglePayView.prototype.ID = constants.paymentOptionIDs.googl
 
 GooglePayView.prototype.initialize = function () {
   var self = this;
-  var buttonOptions;
+  var buttonOptions, googlePayVersion, merchantId;
 
   self.googlePayConfiguration = assign({}, self.model.merchantConfiguration.googlePay);
+  googlePayVersion = self.googlePayConfiguration.googlePayVersion;
+  merchantId = self.googlePayConfiguration.merchantId;
+
+  delete self.googlePayConfiguration.googlePayVersion;
+  delete self.googlePayConfiguration.merchantId;
 
   buttonOptions = assign({
     buttonType: 'short'
@@ -41,8 +46,8 @@ GooglePayView.prototype.initialize = function () {
 
   return btGooglePay.create({
     client: self.client,
-    googlePayVersion: self.googlePayConfiguration.googlePayVersion,
-    googleMerchantId: self.googlePayConfiguration.merchantId
+    googlePayVersion: googlePayVersion,
+    googleMerchantId: merchantId
   }).then(function (googlePayInstance) {
     self.googlePayInstance = googlePayInstance;
     self.paymentsClient = createPaymentsClient(self.client);

--- a/src/views/payment-sheet-views/google-pay-view.js
+++ b/src/views/payment-sheet-views/google-pay-view.js
@@ -39,7 +39,11 @@ GooglePayView.prototype.initialize = function () {
 
   self.model.asyncDependencyStarting();
 
-  return btGooglePay.create({client: self.client}).then(function (googlePayInstance) {
+  return btGooglePay.create({
+    client: self.client,
+    googlePayVersion: self.googlePayConfiguration.googlePayVersion,
+    googleMerchantId: self.googlePayConfiguration.merchantId
+  }).then(function (googlePayInstance) {
     self.googlePayInstance = googlePayInstance;
     self.paymentsClient = createPaymentsClient(self.client);
   }).then(function () {

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -128,6 +128,7 @@
     },
     googlePay: {
       // merchantId: 'merchant-id', // prod id goes here
+      googlePayVersion: 2,
       transactionInfo: {
         currencyCode: 'USD',
         totalPriceStatus: 'FINAL',

--- a/test/unit/views/payment-sheet-views/google-pay-view.js
+++ b/test/unit/views/payment-sheet-views/google-pay-view.js
@@ -118,10 +118,34 @@ describe('GooglePayView', function () {
       }.bind(this));
     });
 
-    it('creates a GooglePay component', function () {
+    it('creates a GooglePayment component', function () {
       return this.view.initialize().then(function () {
         expect(btGooglePay.create).to.be.calledWith(this.sandbox.match({
           client: this.view.client
+        }));
+        expect(this.view.googlePayInstance).to.equal(this.fakeGooglePayInstance);
+      }.bind(this));
+    });
+
+    it('can configure GooglePayment component with googleApiVersion', function () {
+      this.model.merchantConfiguration.googlePay.googlePayVersion = 2;
+
+      return this.view.initialize().then(function () {
+        expect(btGooglePay.create).to.be.calledWith(this.sandbox.match({
+          client: this.view.client,
+          googlePayVersion: 2
+        }));
+        expect(this.view.googlePayInstance).to.equal(this.fakeGooglePayInstance);
+      }.bind(this));
+    });
+
+    it('can configure GooglePayment component with googleMerchantId', function () {
+      this.model.merchantConfiguration.googlePay.merchantId = 'foobar';
+
+      return this.view.initialize().then(function () {
+        expect(btGooglePay.create).to.be.calledWith(this.sandbox.match({
+          client: this.view.client,
+          googleMerchantId: 'foobar'
         }));
         expect(this.view.googlePayInstance).to.equal(this.fakeGooglePayInstance);
       }.bind(this));

--- a/test/unit/views/payment-sheet-views/google-pay-view.js
+++ b/test/unit/views/payment-sheet-views/google-pay-view.js
@@ -272,7 +272,6 @@ describe('GooglePayView', function () {
       return this.view.tokenize().then(function () {
         expect(this.fakeGooglePayInstance.createPaymentDataRequest).to.be.calledOnce;
         expect(this.fakeGooglePayInstance.createPaymentDataRequest).to.be.calledWith({
-          merchantId: 'merchant-id',
           transactionInfo: {
             currencyCode: 'USD',
             totalPriceStatus: 'FINAL',


### PR DESCRIPTION
### Summary

Allows Google Pay to use pre-configured v2 configuration.

### Checklist

- [x] Added a changelog entry
