### PR TITLE
Allow "" and `false` cvv override values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+- Fix issue where falsey values were not allowed as CVV placeholders
+
 1.16.0
 ------
 - Allow `ApplePaySession` version to be set

--- a/spec/card_customization_spec.rb
+++ b/spec/card_customization_spec.rb
@@ -89,6 +89,20 @@ describe "Drop-in card.cardholderName" do
       end
     end
 
+    it "can override field configurations with falsey values" do
+      options = '{"overrides":{"fields":{"cvv":{"placeholder":""}}}}'
+      visit_dropin_url("?card=#{options}")
+
+      click_option("card")
+      hosted_field_send_input("number", "4111111111111111")
+
+      iframe = find("iframe[id='braintree-hosted-field-cvv']")
+
+      page.within_frame(iframe) do
+        expect(find("input").native.attribute("placeholder")).to eq("")
+      end
+    end
+
     it "can override style configurations" do
       options = '{"overrides":{"styles":{"input":{"font-size":"20px"},".number":{"font-size":"10px"}}}}'
       visit_dropin_url("?card=#{options}")

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -203,7 +203,7 @@ CardView.prototype._generateHostedFieldsOptions = function () {
   if (!overrides) { return options; }
 
   if (overrides.fields) {
-    if (overrides.fields.cvv && overrides.fields.cvv.placeholder !== undefined) {
+    if (overrides.fields.cvv && typeof overrides.fields.cvv.placeholder !== 'undefined') {
       this._hasCustomCVVPlaceholder = true;
     }
 

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -203,7 +203,7 @@ CardView.prototype._generateHostedFieldsOptions = function () {
   if (!overrides) { return options; }
 
   if (overrides.fields) {
-    if (overrides.fields.cvv && overrides.fields.cvv.placeholder) {
+    if (overrides.fields.cvv && overrides.fields.cvv.placeholder !== 'undefined') {
       this._hasCustomCVVPlaceholder = true;
     }
 

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -203,7 +203,7 @@ CardView.prototype._generateHostedFieldsOptions = function () {
   if (!overrides) { return options; }
 
   if (overrides.fields) {
-    if (overrides.fields.cvv && overrides.fields.cvv.placeholder !== 'undefined') {
+    if (overrides.fields.cvv && overrides.fields.cvv.placeholder !== undefined) {
       this._hasCustomCVVPlaceholder = true;
     }
 


### PR DESCRIPTION
### Summary

Follow up to https://github.com/braintree/braintree-web-drop-in/issues/447 - there is a bug where falsey override values work on first load, but are cleared and replaced with the default when the drop-in is interacted with. This resolves that bug by being more explicit about what is and is not a `customCVVPlaceholder`.

@crookedneighbor 

### Checklist

- [ ] Added a changelog entry
