### PR TITLE
bump braintree-web version to 3.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 ----------
 - Fix issue where falsey values were not allowed as CVV placeholders
 - Add ability to opt out of card view by passing `false` as the card option
-- Update braintree-web to v3.43.0
+- Update braintree-web to v3.44.0
 - Fix issue where requestable event fires when cancelling payment method deletion (#477)
 
 1.16.0

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vinyl-source-stream": "2.0.0"
   },
   "dependencies": {
-    "braintree-web": "3.43.0",
+    "braintree-web": "3.44.0",
     "@braintree/asset-loader": "0.2.1",
     "@braintree/browser-detection": "1.7.0",
     "@braintree/class-list": "0.1.0",


### PR DESCRIPTION
### Summary

Updates to the newest version of braintree-web
### Checklist

- [X] Added a changelog entry
