### PR TITLE
Update braintree-web to v3.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 CHANGELOG
 =========
 
-1.17.0
+unreleased
 ----------
+- Update braintree-web to v3.44.1
+  - Fixes issue with mobile tabbing in the card form
+
+1.17.0
+------
 - Fix issue where falsey values were not allowed as CVV placeholders
 - Add ability to opt out of card view by passing `false` as the card option
 - Update braintree-web to v3.44.0

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vinyl-source-stream": "2.0.0"
   },
   "dependencies": {
-    "braintree-web": "3.44.0",
+    "braintree-web": "3.44.1",
     "@braintree/asset-loader": "0.2.1",
     "@braintree/browser-detection": "1.7.0",
     "@braintree/class-list": "0.1.0",


### PR DESCRIPTION
### Summary

Updates braintree-web to v3.44.1

### Checklist

- [x] Added a changelog entry
