### PR TITLE
Update braintree-web to v3.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+Unreleased
+------
+- Update braintree-web to v3.44.2
+- Google Pay
+  - Fix issue where tokenization details for Google Payments could accidentally be dropped
+- PayPal
+  - Fix bug where merchant account id was not being applied in vault flows
+
 1.17.1
 ------
 - Update braintree-web to v3.44.1

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vinyl-source-stream": "2.0.0"
   },
   "dependencies": {
-    "braintree-web": "3.44.1",
+    "braintree-web": "3.44.2",
     "@braintree/asset-loader": "0.2.1",
     "@braintree/browser-detection": "1.7.0",
     "@braintree/class-list": "0.1.0",


### PR DESCRIPTION
### Summary

braintree-web has been updated to v3.44.2

### Checklist

- [x] Added a changelog entry
