### PR TITLE
Measurements are now with consistent relative to their parent element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ------
 - Replace css preprocessor, from [Sass](https://sass-lang.com) to [Less](http://lesscss.org)
+- Adjust delete confirmation box css to be consistent, all relative to own parent.
 
 1.18.0
 ------

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -866,13 +866,13 @@
 
 .braintree-delete-confirmation {
   display: none;
-  overflow: none;
+  overflow: hidden;
   background: #FAFAFA !important;
   color: #606060;
-  font-size: .85rem;
+  font-size: 1.125em;
 
   [data-braintree-id="delete-confirmation__message"] {
-    padding: 40px;
+    padding: 2.5em;
     text-align: center;
   }
 
@@ -883,12 +883,12 @@
     .braintree-delete-confirmation__button {
       border: none;
       border-top: 1px solid #B5B5B5;
-      font-size: .9em;
+      font-size: 1em;
       background: #FAFAFA;
       color: #C4C4C4;
       cursor: pointer;
       flex-grow: 2;
-      padding: .7em;
+      padding: 0.75em;
     }
 
     [data-braintree-id="delete-confirmation__yes"] {
@@ -903,7 +903,7 @@
 
     [data-braintree-id="delete-confirmation__no"] {
       color: @black-40;
-      border-bottom-left-radius: 4px;
+      border-bottom-left-radius: 0.25em;
 
       &:hover {
         background: darken(@background-hover, 5%);


### PR DESCRIPTION
### Summary

Appearance on drop-in
<img width="407" alt="raqij" src="https://user-images.githubusercontent.com/782056/57663517-2ad47400-75a9-11e9-893a-7c5d4c712582.png">
(disregard "purchase" button, that's part of the [codepen](https://codepen.io/braintree/pen/5de79e5d7ffe1cab6d03c93151856aed) I was experimenting on 

Appearance on drop-in with Bootstrap 3
<img width="411" alt="q4p0i" src="https://user-images.githubusercontent.com/782056/57663533-36279f80-75a9-11e9-8339-3acf4eeea9af.png">

Closes #497

### Checklist

- [x] Added a changelog entry