### PR TITLE
Add analytic events for vaulted cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ------
 - Replace css preprocessor, from [Sass](https://sass-lang.com) to [Less](http://lesscss.org)
+- Adjust delete confirmation box css to be consistent, all relative to own parent.
 
 1.18.0
 ------

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -565,14 +565,23 @@ Dropin.prototype._disableErroredPaymentMethods = function () {
   }.bind(this));
 };
 
-Dropin.prototype._vaultedCardAppearAnalyticEvent = function () {
-  var i;
+Dropin.prototype._sendVaultedPaymentMethodAppearAnalyticsEvents = function () {
+  var i, type;
+  var typesThatSentAnEvent = {};
+  var paymentMethods = this._model._paymentMethods;
 
-  for (i = 0; i < this._model._paymentMethods.length; i++) {
-    if (this._model._paymentMethods[i].type === 'CreditCard') {
-      analytics.sendEvent(this._client, 'vaulted-card.appear');
-      break;
+  for (i = 0; i < paymentMethods.length; i++) {
+    type = paymentMethods[i].type;
+
+    if (type in typesThatSentAnEvent) {
+      // prevents us from sending the analytic multiple times
+      // for the same payment method type
+      continue;
     }
+
+    typesThatSentAnEvent[type] = true;
+
+    analytics.sendEvent(this._client, 'vaulted-' + constants.analyticsKinds[type] + '.appear');
   }
 };
 
@@ -583,7 +592,7 @@ Dropin.prototype._handleAppSwitch = function () {
   } else if (this._model.appSwitchPayload) {
     this._model.addPaymentMethod(this._model.appSwitchPayload);
   } else {
-    this._vaultedCardAppearAnalyticEvent();
+    this._sendVaultedPaymentMethodAppearAnalyticsEvents();
   }
 };
 

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -341,6 +341,8 @@ Dropin.prototype._initialize = function (callback) {
         analytics.sendEvent(self._client, 'appeared');
         self._disableErroredPaymentMethods();
 
+        self._vaultedCardAppearAnalyticEvent();
+
         self._handleAppSwitch();
 
         callback(null, self);
@@ -563,6 +565,17 @@ Dropin.prototype._disableErroredPaymentMethods = function () {
     errorMessageDiv.innerHTML = constants.errors.DEVELOPER_MISCONFIGURATION_MESSAGE;
     console.error(error); // eslint-disable-line no-console
   }.bind(this));
+};
+
+Dropin.prototype._vaultedCardAppearAnalyticEvent = function () {
+  var i;
+
+  for (i = 0; i < this._model._paymentMethods.length; i++) {
+    if (this._model._paymentMethods[i].type === 'CreditCard') {
+      analytics.sendEvent(this._client, 'vaulted-card.appear');
+      break;
+    }
+  }
 };
 
 Dropin.prototype._handleAppSwitch = function () {

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -341,8 +341,6 @@ Dropin.prototype._initialize = function (callback) {
         analytics.sendEvent(self._client, 'appeared');
         self._disableErroredPaymentMethods();
 
-        self._vaultedCardAppearAnalyticEvent();
-
         self._handleAppSwitch();
 
         callback(null, self);
@@ -584,6 +582,8 @@ Dropin.prototype._handleAppSwitch = function () {
     this._model.reportError(this._model.appSwitchError.error);
   } else if (this._model.appSwitchPayload) {
     this._model.addPaymentMethod(this._model.appSwitchPayload);
+  } else {
+    this._vaultedCardAppearAnalyticEvent();
   }
 };
 

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -866,13 +866,13 @@
 
 .braintree-delete-confirmation {
   display: none;
-  overflow: none;
+  overflow: hidden;
   background: #FAFAFA !important;
   color: #606060;
-  font-size: .85rem;
+  font-size: 1.125em;
 
   [data-braintree-id="delete-confirmation__message"] {
-    padding: 40px;
+    padding: 2.5em;
     text-align: center;
   }
 
@@ -883,12 +883,12 @@
     .braintree-delete-confirmation__button {
       border: none;
       border-top: 1px solid #B5B5B5;
-      font-size: .9em;
+      font-size: 1em;
       background: #FAFAFA;
       color: #C4C4C4;
       cursor: pointer;
       flex-grow: 2;
-      padding: .7em;
+      padding: 0.75em;
     }
 
     [data-braintree-id="delete-confirmation__yes"] {
@@ -903,7 +903,7 @@
 
     [data-braintree-id="delete-confirmation__no"] {
       color: @black-40;
-      border-bottom-left-radius: 4px;
+      border-bottom-left-radius: 0.25em;
 
       &:hover {
         background: darken(@background-hover, 5%);

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -137,7 +137,6 @@ MainView.prototype._onChangeActivePaymentMethodView = function (id) {
   if (id === PaymentMethodsView.ID) {
     classList.add(this.paymentMethodsViews.container, 'braintree-methods--active');
     classList.remove(this.sheetContainer, 'braintree-sheet--active');
-    this.vaultedCardSelectAnalyticEvent();
   } else {
     setTimeout(function () {
       classList.add(this.sheetContainer, 'braintree-sheet--active');
@@ -151,14 +150,6 @@ MainView.prototype._onChangeActivePaymentMethodView = function (id) {
   }
 
   activePaymentView.onSelection();
-};
-
-MainView.prototype.vaultedCardSelectAnalyticEvent = function () {
-  if (this.shouldSendSelectEvent === false) {
-    this.shouldSendSelectEvent = true;
-  } else {
-    analytics.sendEvent(this.client, 'vaulted-card.select');
-  }
 };
 
 MainView.prototype.addView = function (view) {
@@ -216,7 +207,6 @@ MainView.prototype.requestPaymentMethod = function () {
 
   return activePaymentView.requestPaymentMethod().then(function (payload) {
     analytics.sendEvent(this.client, 'request-payment-method.' + analyticsKinds[payload.type]);
-    this.shouldSendSelectEvent = false;
 
     return payload;
   }.bind(this)).catch(function (err) {
@@ -325,7 +315,6 @@ MainView.prototype.teardown = function () {
 };
 
 MainView.prototype.enableEditMode = function () {
-  this.shouldSendSelectEvent = false;
   this.setPrimaryView(this.paymentMethodsViews.ID);
   this.paymentMethodsViews.enableEditMode();
   this.hideToggle();
@@ -391,7 +380,6 @@ MainView.prototype._sendToDefaultView = function () {
   var preselectVaultedPaymentMethod = this.model.merchantConfiguration.preselectVaultedPaymentMethod !== false;
 
   if (paymentMethods.length > 0) {
-    this.shouldSendSelectEvent = false;
     if (preselectVaultedPaymentMethod) {
       analytics.sendEvent(this.client, 'vaulted-card.preselect');
 

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -96,27 +96,7 @@ MainView.prototype._initialize = function () {
     }.bind(this), CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT);
   }.bind(this));
 
-  this.model.on('changeActivePaymentView', function (id) {
-    var activePaymentView = this.getView(id);
-
-    if (id === PaymentMethodsView.ID) {
-      classList.add(this.paymentMethodsViews.container, 'braintree-methods--active');
-      classList.remove(this.sheetContainer, 'braintree-sheet--active');
-      this.vaultedCardSelectAnalyticEvent();
-    } else {
-      setTimeout(function () {
-        classList.add(this.sheetContainer, 'braintree-sheet--active');
-      }.bind(this), 0);
-      classList.remove(this.paymentMethodsViews.container, 'braintree-methods--active');
-      if (!this.getView(id).getPaymentMethod()) {
-        this.model.setPaymentMethodRequestable({
-          isRequestable: false
-        });
-      }
-    }
-
-    activePaymentView.onSelection();
-  }.bind(this));
+  this.model.on('changeActivePaymentView', this._onChangeActivePaymentMethodView.bind(this));
 
   this.model.on('removeActivePaymentMethod', function () {
     var activePaymentView = this.getView(this.model.getActivePaymentView());
@@ -148,6 +128,28 @@ MainView.prototype._initialize = function () {
   }
 
   this._sendToDefaultView();
+};
+
+MainView.prototype._onChangeActivePaymentMethodView = function (id) {
+  var activePaymentView = this.getView(id);
+
+  if (id === PaymentMethodsView.ID) {
+    classList.add(this.paymentMethodsViews.container, 'braintree-methods--active');
+    classList.remove(this.sheetContainer, 'braintree-sheet--active');
+    this.vaultedCardSelectAnalyticEvent();
+  } else {
+    setTimeout(function () {
+      classList.add(this.sheetContainer, 'braintree-sheet--active');
+    }.bind(this), 0);
+    classList.remove(this.paymentMethodsViews.container, 'braintree-methods--active');
+    if (!this.getView(id).getPaymentMethod()) {
+      this.model.setPaymentMethodRequestable({
+        isRequestable: false
+      });
+    }
+  }
+
+  activePaymentView.onSelection();
 };
 
 MainView.prototype.vaultedCardSelectAnalyticEvent = function () {
@@ -388,9 +390,9 @@ MainView.prototype._sendToDefaultView = function () {
   var preselectVaultedPaymentMethod = this.model.merchantConfiguration.preselectVaultedPaymentMethod !== false;
 
   if (paymentMethods.length > 0) {
+    this.shouldSendSelectEvent = false;
     if (preselectVaultedPaymentMethod) {
       analytics.sendEvent(this.client, 'vaulted-card.preselect');
-      this.shouldSendSelectEvent = false;
 
       this.model.changeActivePaymentMethod(paymentMethods[0]);
     } else {

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -102,6 +102,7 @@ MainView.prototype._initialize = function () {
     if (id === PaymentMethodsView.ID) {
       classList.add(this.paymentMethodsViews.container, 'braintree-methods--active');
       classList.remove(this.sheetContainer, 'braintree-sheet--active');
+      this.vaultedCardSelectAnalyticEvent();
     } else {
       setTimeout(function () {
         classList.add(this.sheetContainer, 'braintree-sheet--active');
@@ -147,6 +148,14 @@ MainView.prototype._initialize = function () {
   }
 
   this._sendToDefaultView();
+};
+
+MainView.prototype.vaultedCardSelectAnalyticEvent = function () {
+  if (this.shouldSendSelectEvent === false) {
+    this.shouldSendSelectEvent = true;
+  } else {
+    analytics.sendEvent(this.client, 'vaulted-card.select');
+  }
 };
 
 MainView.prototype.addView = function (view) {
@@ -204,6 +213,7 @@ MainView.prototype.requestPaymentMethod = function () {
 
   return activePaymentView.requestPaymentMethod().then(function (payload) {
     analytics.sendEvent(this.client, 'request-payment-method.' + analyticsKinds[payload.type]);
+    this.shouldSendSelectEvent = false;
 
     return payload;
   }.bind(this)).catch(function (err) {
@@ -312,6 +322,7 @@ MainView.prototype.teardown = function () {
 };
 
 MainView.prototype.enableEditMode = function () {
+  this.shouldSendSelectEvent = false;
   this.setPrimaryView(this.paymentMethodsViews.ID);
   this.paymentMethodsViews.enableEditMode();
   this.hideToggle();
@@ -378,6 +389,9 @@ MainView.prototype._sendToDefaultView = function () {
 
   if (paymentMethods.length > 0) {
     if (preselectVaultedPaymentMethod) {
+      analytics.sendEvent(this.client, 'vaulted-card.preselect');
+      this.shouldSendSelectEvent = false;
+
       this.model.changeActivePaymentMethod(paymentMethods[0]);
     } else {
       this.setPrimaryView(this.paymentMethodsViews.ID);

--- a/src/views/payment-method-view.js
+++ b/src/views/payment-method-view.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var analytics = require('../lib/analytics');
 var BaseView = require('./base-view');
 var classList = require('@braintree/class-list');
 var constants = require('../constants');
@@ -93,6 +94,10 @@ PaymentMethodView.prototype._choosePaymentMethod = function () {
   if (this.model.isInEditMode()) {
     return;
   }
+  if (this.paymentMethod.vaulted) {
+    analytics.sendEvent(this.client, 'vaulted-' + constants.analyticsKinds[this.paymentMethod.type] + '.select');
+  }
+
   this.model.changeActivePaymentMethod(this.paymentMethod);
 };
 

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -582,7 +582,7 @@ describe('Dropin', function () {
       }.bind(this));
     });
 
-    it('does not send web.vaulted-card.appear event when no vaulted cards', function (done) {
+    it('does not send web.vaulted-card.appear analytic event when no vaulted cards appear', function (done) {
       var instance = new Dropin(this.dropinOptions);
 
       this.sandbox.stub(DropinModel.prototype, 'getVaultedPaymentMethods').resolves([

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -46,6 +46,7 @@ describe('Dropin', function () {
       }
     };
 
+    this.sandbox.stub(analytics, 'sendEvent');
     this.sandbox.stub(CardView.prototype, 'getPaymentMethod');
     this.sandbox.stub(hostedFields, 'create').resolves(fake.hostedFieldsInstance);
     this.sandbox.stub(paypalCheckout, 'create').resolves(fake.paypalInstance);
@@ -92,8 +93,6 @@ describe('Dropin', function () {
 
       delete this.dropinOptions.merchantConfiguration.container;
 
-      this.sandbox.stub(analytics, 'sendEvent');
-
       instance = new Dropin(this.dropinOptions);
 
       instance._initialize(function (err) {
@@ -107,8 +106,6 @@ describe('Dropin', function () {
       var instance;
 
       this.dropinOptions.merchantConfiguration.selector = {value: '#bar'};
-
-      this.sandbox.stub(analytics, 'sendEvent');
 
       instance = new Dropin(this.dropinOptions);
 
@@ -127,7 +124,6 @@ describe('Dropin', function () {
       hostedFields.create.rejects(hostedFieldsError);
       paypalCheckout.create.rejects(paypalError);
 
-      this.sandbox.stub(analytics, 'sendEvent');
       this.dropinOptions.merchantConfiguration.paypal = {flow: 'vault'};
 
       instance = new Dropin(this.dropinOptions);
@@ -195,8 +191,6 @@ describe('Dropin', function () {
 
       this.dropinOptions.merchantConfiguration.container = '#garbage';
 
-      this.sandbox.stub(analytics, 'sendEvent');
-
       instance = new Dropin(this.dropinOptions);
 
       instance._initialize(function (err) {
@@ -212,8 +206,6 @@ describe('Dropin', function () {
       var div = document.createElement('div');
 
       this.container.appendChild(div);
-
-      this.sandbox.stub(analytics, 'sendEvent');
 
       instance = new Dropin(this.dropinOptions);
 
@@ -233,8 +225,6 @@ describe('Dropin', function () {
 
       this.dropinOptions.merchantConfiguration.container = this.container;
 
-      this.sandbox.stub(analytics, 'sendEvent');
-
       instance = new Dropin(this.dropinOptions);
 
       instance._initialize(function (err) {
@@ -250,8 +240,6 @@ describe('Dropin', function () {
       var fakeDiv = {appendChild: 'fake'};
 
       this.dropinOptions.merchantConfiguration.container = fakeDiv;
-
-      this.sandbox.stub(analytics, 'sendEvent');
 
       instance = new Dropin(this.dropinOptions);
 
@@ -384,8 +372,6 @@ describe('Dropin', function () {
       });
       this.client.request.rejects(new Error('This failed'));
 
-      this.sandbox.stub(analytics, 'sendEvent');
-
       instance = new Dropin(this.dropinOptions);
 
       instance._initialize(function () {
@@ -406,8 +392,6 @@ describe('Dropin', function () {
         gatewayConfiguration: fake.configuration().gatewayConfiguration
       });
       this.client.request.resolves(paymentMethodsPayload);
-
-      this.sandbox.stub(analytics, 'sendEvent');
 
       instance = new Dropin(this.dropinOptions);
 
@@ -496,7 +480,6 @@ describe('Dropin', function () {
 
       this.sandbox.stub(DropinModel.prototype, 'asyncDependencyStarting');
       this.sandbox.stub(DropinModel.prototype, 'asyncDependencyReady');
-      this.sandbox.stub(analytics, 'sendEvent');
 
       instance._initialize(function () {
         expect(analytics.sendEvent).to.be.calledOnce;
@@ -531,7 +514,6 @@ describe('Dropin', function () {
       this.sandbox.stub(DropinModel.prototype, 'getVaultedPaymentMethods').resolves([
         {type: 'PayPalAccount', details: {email: 'wow@example.com'}}
       ]);
-      this.sandbox.stub(analytics, 'sendEvent');
 
       instance._initialize(function () {
         expect(analytics.sendEvent).to.not.be.calledWith(instance._client, 'vaulted-card.appear');

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -510,6 +510,35 @@ describe('Dropin', function () {
       });
     });
 
+    it('sends web.vaulted-card.appear event when vaulted cards are available', function (done) {
+      var instance = new Dropin(this.dropinOptions);
+
+      this.sandbox.stub(DropinModel.prototype, 'getVaultedPaymentMethods').resolves([
+        {type: 'CreditCard', details: {lastTwo: '11'}},
+        {type: 'PayPalAccount', details: {email: 'wow@example.com'}}
+      ]);
+      this.sandbox.stub(analytics, 'sendEvent');
+
+      instance._initialize(function () {
+        expect(analytics.sendEvent).to.be.calledWith(instance._client, 'vaulted-card.appear');
+        done();
+      });
+    });
+
+    it('does not send web.vaulted-card.appear event when no vaulted cards', function (done) {
+      var instance = new Dropin(this.dropinOptions);
+
+      this.sandbox.stub(DropinModel.prototype, 'getVaultedPaymentMethods').resolves([
+        {type: 'PayPalAccount', details: {email: 'wow@example.com'}}
+      ]);
+      this.sandbox.stub(analytics, 'sendEvent');
+
+      instance._initialize(function () {
+        expect(analytics.sendEvent).to.not.be.calledWith(instance._client, 'vaulted-card.appear');
+        done();
+      });
+    });
+
     it('loads strings by default', function (done) {
       var instance = new Dropin(this.dropinOptions);
 

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -209,15 +209,14 @@ describe('MainView', function () {
       });
 
       it('sends preselect analytic event when a vaulted card is preselected', function () {
-        new MainView(this.mainViewOptions); // eslint-disable-line no-new
         this.model.merchantConfiguration.preselectVaultedPaymentMethod = true;
+        new MainView(this.mainViewOptions); // eslint-disable-line no-new
 
         expect(analytics.sendEvent).to.be.calledWith(this.client, 'vaulted-card.preselect');
       });
 
       it('does not send preselect analytic event when a vaulted card is not preselected', function () {
         this.model.merchantConfiguration.preselectVaultedPaymentMethod = false;
-        this.sandbox.spy(this.model, 'changeActivePaymentMethod');
 
         new MainView(this.mainViewOptions); // eslint-disable-line no-new
 
@@ -792,7 +791,7 @@ describe('MainView', function () {
         it('does not send select analytic event when shouldSendSelectEvent is false', function () {
           this.mainView.shouldSendSelectEvent = false;
           this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
-          expect(analytics.sendEvent).to.not.be.calledWith(this.client, 'vaulted-card.select');
+          expect(analytics.sendEvent).to.not.be.calledWith(this.sandbox.match.any, 'vaulted-card.select');
         });
       });
 

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -781,18 +781,6 @@ describe('MainView', function () {
           this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(this.mainView._views.methods.onSelection).to.be.calledOnce;
         });
-
-        it('sends select analytic event sent when shouldSendSelectEvent is true', function () {
-          this.mainView.shouldSendSelectEvent = true;
-          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
-          expect(analytics.sendEvent).to.be.calledWith(this.client, 'vaulted-card.select');
-        });
-
-        it('does not send select analytic event when shouldSendSelectEvent is false', function () {
-          this.mainView.shouldSendSelectEvent = false;
-          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
-          expect(analytics.sendEvent).to.not.be.calledWith(this.sandbox.match.any, 'vaulted-card.select');
-        });
       });
 
       describe('when a payment sheet is active', function () {

--- a/test/unit/views/main-view.js
+++ b/test/unit/views/main-view.js
@@ -764,34 +764,34 @@ describe('MainView', function () {
         });
 
         it('adds braintree-methods--active to the payment methods view element', function () {
-          this.mainView._onChangeActivePaymentMethodView(PaymentMethodsView.ID);
+          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(this.paymentMethodsContainer.className).to.contain('braintree-methods--active');
         });
 
         it('removes braintree-sheet--active from the payment sheet element', function () {
-          this.mainView._onChangeActivePaymentMethodView(PaymentMethodsView.ID);
+          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(this.sheetElement.className).to.not.contain('braintree-sheet--active');
         });
 
         it('does not call model.setPaymentMethodRequestable', function () {
-          this.mainView._onChangeActivePaymentMethodView(PaymentMethodsView.ID);
+          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(this.model.setPaymentMethodRequestable).to.not.be.called;
         });
 
         it('calls onSelection', function () {
-          this.mainView._onChangeActivePaymentMethodView(PaymentMethodsView.ID);
+          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(this.mainView._views.methods.onSelection).to.be.calledOnce;
         });
 
         it('sends select analytic event sent when shouldSendSelectEvent is true', function () {
           this.mainView.shouldSendSelectEvent = true;
-          this.mainView._onChangeActivePaymentMethodView(PaymentMethodsView.ID);
+          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(analytics.sendEvent).to.be.calledWith(this.client, 'vaulted-card.select');
         });
 
         it('does not send select analytic event when shouldSendSelectEvent is false', function () {
           this.mainView.shouldSendSelectEvent = false;
-          this.mainView._onChangeActivePaymentMethodView(PaymentMethodsView.ID);
+          this.model._emit('changeActivePaymentView', PaymentMethodsView.ID);
           expect(analytics.sendEvent).to.not.be.calledWith(this.client, 'vaulted-card.select');
         });
       });

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -251,7 +251,7 @@ describe('PaymentMethodView', function () {
       expect(analytics.sendEvent.withArgs(this.client, 'vaulted-paypal.select')).to.be.calledOnce;
     });
 
-    it.only('does not send an analytic event when no payment is selected', function () {
+    it('does not send an analytic event when no payment is selected', function () {
       var view = new PaymentMethodView({
         client: this.client,
         model: this.model,

--- a/test/unit/views/payment-method-view.js
+++ b/test/unit/views/payment-method-view.js
@@ -205,14 +205,14 @@ describe('PaymentMethodView', function () {
     });
   });
 
-  describe('selecting vaulted payment methods', function () {
+  describe('selecting payment methods', function () {
     beforeEach(function () {
       this.client = fake.client();
       this.model = fake.model();
       this.sandbox.stub(analytics, 'sendEvent');
     });
 
-    it('sends analytic event when vaulted card selected', function () {
+    it('sends an analytic event when a vaulted card is selected', function () {
       var view = new PaymentMethodView({
         client: this.client,
         model: this.model,
@@ -232,7 +232,7 @@ describe('PaymentMethodView', function () {
       expect(analytics.sendEvent.withArgs(this.client, 'vaulted-card.select')).to.be.calledOnce;
     });
 
-    it('sends analytic event when vaulted paypal selected', function () {
+    it('sends an analytic event when a vaulted paypal payment method is selected', function () {
       var view = new PaymentMethodView({
         client: this.client,
         model: this.model,
@@ -251,11 +251,20 @@ describe('PaymentMethodView', function () {
       expect(analytics.sendEvent.withArgs(this.client, 'vaulted-paypal.select')).to.be.calledOnce;
     });
 
-    it('does not send analytic event when no vault payment selected', function () {
+    it.only('does not send an analytic event when no payment is selected', function () {
+      var view = new PaymentMethodView({
+        client: this.client,
+        model: this.model,
+        strings: strings,
+        paymentMethod: {}
+      });
+
+      view._choosePaymentMethod();
+
       expect(analytics.sendEvent.withArgs(this.client, 'vaulted-card.select')).to.not.be.called;
     });
 
-    it('does not send analytic event when non-vaulted paypal selected', function () {
+    it('does not send an analytic event when a non-vaulted PayPal payment method is selected', function () {
       var view = new PaymentMethodView({
         client: this.client,
         model: this.model,
@@ -272,10 +281,6 @@ describe('PaymentMethodView', function () {
       view._choosePaymentMethod();
 
       expect(analytics.sendEvent.withArgs(this.client, 'vaulted-paypal.select')).to.not.be.called;
-    });
-
-    it('does not send analytic event when no vault payment selected', function () {
-      expect(analytics.sendEvent.withArgs(this.client, 'vaulted-card.select')).to.not.be.called;
     });
   });
 


### PR DESCRIPTION
### Summary

Adds the following analytic events:
- `vaulted-card.appear`, which is sent when the Drop-In is initialized and vaulted cards were presented
- `vaulted-card.preselect`, which is sent when the Drop-In is initialized (or the view is refreshed) and a vaulted card is preselected (the green check box)
- `vaulted-card.select`, which is sent when a vaulted card is selected by the user

These events are slightly different than the mobile SDKs, in that only the JS Drop-In only has preselect behavior.

### Checklist

- [X] Added a changelog entry