### PR TITLE
Reject promise in Braintree requestPaymentMethod to conform to pattern

### DIFF
--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -105,7 +105,7 @@ BasePayPalView.prototype.initialize = function () {
 BasePayPalView.prototype.requestPaymentMethod = function () {
   this.model.reportError('paypalButtonMustBeUsed');
 
-  return Promise.reject(new DropinError(constants.errors.NO_PAYMENT_METHOD_ERROR));
+  return BaseView.prototype.requestPaymentMethod.call(this)
 };
 
 BasePayPalView.prototype.updateConfiguration = function (key, value) {

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -104,6 +104,8 @@ BasePayPalView.prototype.initialize = function () {
 
 BasePayPalView.prototype.requestPaymentMethod = function () {
   this.model.reportError('paypalButtonMustBeUsed');
+
+  return Promise.reject(new DropinError(constants.errors.NO_PAYMENT_METHOD_ERROR));
 };
 
 BasePayPalView.prototype.updateConfiguration = function (key, value) {

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -105,7 +105,7 @@ BasePayPalView.prototype.initialize = function () {
 BasePayPalView.prototype.requestPaymentMethod = function () {
   this.model.reportError('paypalButtonMustBeUsed');
 
-  return BaseView.prototype.requestPaymentMethod.call(this)
+  return BaseView.prototype.requestPaymentMethod.call(this);
 };
 
 BasePayPalView.prototype.updateConfiguration = function (key, value) {

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -938,4 +938,14 @@ describe('BasePayPalView', function () {
       });
     });
   });
+
+  describe('requestPaymentMethod', function () {
+    it('always rejects', function () {
+      var view = new BasePayPalView(this.paypalViewOptions);
+
+      return view.requestPaymentMethod().then(
+        function () { expect(true).to.equal(false); },
+        function () { expect(true).to.equal(true); });
+    });
+  });
 });


### PR DESCRIPTION
### Summary

We're currently using the dropin on our checkout page, where we support Credit Card and Paypal. Our (simplified) flow looks like this:
1) Mount the Braintree drop in, with our custom Submit Checkout button disabled
2) Enable Submit Checkout button after user has selected a payment method
3) On Submit Checkout button pressed, call `requestPaymentMethod` on the dropin to fetch payment nonce
4) If `requestPaymentMethod` resolves with nonce, submit checkout. Otherwise show error.

This flow throws an error in one case. If the user has selected Paypal, but hasn't yet clicked on the Paypal button that starts the modal Paypal authentication flow, the dropin will end up hitting `BasePayPalView.requestPaymentMethod()`, which isn't currently returning a promise. That breaks the flow, because [the calling function always expects a promise](https://github.com/braintree/braintree-web-drop-in/blob/master/src/views/main-view.js#L206-L208) to be returned by the payment view's `requestPaymentMethod`, so the dropin ends up throwing `Cannot read property 'then' of undefined`

This PR fixes the situation by returning a rejected promise, so that the PayPal view conforms to the contract that the main view is expecting.

tldr
`main-view.js` [expects every payment view's requestPaymentMethod returns a promise](https://github.com/braintree/braintree-web-drop-in/blob/master/src/views/main-view.js#L206-L208), PayPal view [doesn't return a promise](https://github.com/braintree/braintree-web-drop-in/blob/master/src/views/payment-sheet-views/base-paypal-view.js#L105-L107).

### Checklist

- [ ] Added a changelog entry