### PR TITLE
Fix 3DS scrolling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Update braintree-web to v3.51.0
 - Update browser-detection to v1.8.0
+- Fix issue where 3D Secure iframe may not be scrollable on devices with small screens
 
 1.19.0
 ------

--- a/src/less/cardinal-overrides.less
+++ b/src/less/cardinal-overrides.less
@@ -1,0 +1,19 @@
+// Cardinal's 3ds modal has a bug where iframes
+// viewed on iOS do not scroll properly, causing
+// the customer to not be able to authenticate
+// with their bank. When Songbird.js is updated
+// to fix these issues, we can remove these styles
+// fix found here: https://davidwalsh.name/scroll-iframes-ios
+#Cardinal-Modal {
+	top: 10px !important;
+	bottom: 10px !important;
+	left: 10px !important;
+	right: 10px !important;
+	transform: none !important;
+	overflow: scroll !important;
+	-webkit-overflow-scrolling: touch !important;
+}
+#Cardinal-Modal iframe {
+	height: 100% !important;
+	width: 100% !important;
+}

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1115,3 +1115,5 @@
     position: absolute;
   }
 }
+
+@import 'cardinal-overrides';


### PR DESCRIPTION
### Summary

Cardinal's songbird.js SDK has some styling around their iframe wrapper that prevents it from scrolling on a mobile device with a small screen (replicated on an iPhone 8). 

This temporary styling overrides those styles provided by Cardinal. This can be removed again when the issue is fixed on Cardinal's side.

### Checklist

- [x] Added a changelog entry