### PR TITLE
Fix issue where css class name could not be passed in as a HF override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ unreleased
   - Update songbird.js script urls for 3D Secure
 - Default 3D Secure ACS Window Size to `03` (see [`acsWindowSize` option](https://braintree.github.io/braintree-web/current/ThreeDSecure.html#verifyCard))
 - Scope full screen 3D Secure modal to screen sizes with heights of 700px and smaller
+- Fix issue where css class names could not be passed as an override style for card form (closes #535)
 
 1.20.0
 ------

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -242,6 +242,11 @@ CardView.prototype._generateHostedFieldsOptions = function () {
         delete options.styles[style];
 
         return;
+      } else if (typeof overrides.styles[style] === 'string') {
+        // it's a class name, and should override the configured styles entirely
+        options.styles[style] = overrides.styles[style];
+
+        return;
       }
 
       normalizeStyles(overrides.styles[style]);

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -660,6 +660,37 @@ describe('CardView', function () {
         });
       });
     });
+
+    it('allows overriding styles options with class name for hosted fields', function () {
+      var hostedFieldsConfiguredStyles;
+
+      this.model.merchantConfiguration.card = {
+        overrides: {
+          styles: {
+            input: 'class-name',
+            ':focus': 'focus-class'
+          }
+        }
+      };
+
+      this.view = new CardView({
+        element: this.element,
+        mainView: this.mainView,
+        model: this.model,
+        client: this.client,
+        strings: strings
+      });
+
+      return this.view.initialize().then(function () {
+        hostedFieldsConfiguredStyles = hostedFields.create.lastCall.args[0].styles;
+
+        expect(hostedFieldsConfiguredStyles.input).to.equal('class-name');
+        expect(hostedFieldsConfiguredStyles[':focus']).to.equal('focus-class');
+        expect(hostedFieldsConfiguredStyles['input::-ms-clear']).to.deep.equal({
+          color: 'transparent'
+        });
+      });
+    });
   });
 
   describe('isEnabled', function () {


### PR DESCRIPTION
closes #535

### Summary

Hosted Fields supports passing in a class name as a style. (under the hood we compute the style from the class name). Drop-in didn't assume that and would break if a string was passed instead of a style object.

This PR fixes that.

### Checklist

- [x] Added a changelog entry