### PR TITLE
Log developer error for mismatched ApplePay session and iCloud account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ unreleased
   - Update songbird.js script urls for 3D Secure
 - Default 3D Secure ACS Window Size to `03` (see [`acsWindowSize` option](https://braintree.github.io/braintree-web/current/ThreeDSecure.html#verifyCard))
 - Scope full screen 3D Secure modal to screen sizes with heights of 700px and smaller
+- Log developer error for Apple Pay failure when mismatching a Sandbox session with a production iCloud account (closes #522)
 
 1.20.0
 ------

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -44,7 +44,7 @@ ApplePayView.prototype.initialize = function () {
           if (isProduction) {
             self.model.reportError('applePayActiveCardError');
           } else {
-            console.error('Could not find an active card. This may be because you're using a production iCloud account in a sandbox Apple Pay Session. Log in to a Sandbox iCloud account to test this flow, and add a card to your wallet. For additional assistance, visit  https://help.braintreepayments.com'); // eslint-disable-line no-console
+            console.error('Could not find an active card. This may be because you\'re using a production iCloud account in a sandbox Apple Pay Session. Log in to a Sandbox iCloud account to test this flow, and add a card to your wallet. For additional assistance, visit  https://help.braintreepayments.com'); // eslint-disable-line no-console
             self.model.reportError('developerError');
           }
         }

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -44,7 +44,7 @@ ApplePayView.prototype.initialize = function () {
           if (isProduction) {
             self.model.reportError('applePayActiveCardError');
           } else {
-            console.error('Could not find an active card. This may be because your Apple Pay Session was created in the Sandbox environment and your iCloud account is a production account. Log in to a Sandbox iCloud account to test this flow. If you are already logged into an iCloud Sandbox account, then add a card to your wallet.'); // eslint-disable-line no-console
+            console.error('Could not find an active card. This may be because you're using a production iCloud account in a sandbox Apple Pay Session. Log in to a Sandbox iCloud account to test this flow, and add a card to your wallet. For additional assistance, visit  https://help.braintreepayments.com'); // eslint-disable-line no-console
             self.model.reportError('developerError');
           }
         }

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -20,6 +20,7 @@ ApplePayView.ID = ApplePayView.prototype.ID = paymentOptionIDs.applePay;
 
 ApplePayView.prototype.initialize = function () {
   var self = this;
+  var isProduction = self.client.getConfiguration().gatewayConfiguration.environment === 'production';
 
   self.applePayConfiguration = assign({}, self.model.merchantConfiguration.applePay);
   self.applePaySessionVersion = self.applePayConfiguration.applePaySessionVersion || DEFAULT_APPLE_PAY_SESSION_VERSION;
@@ -40,7 +41,12 @@ ApplePayView.prototype.initialize = function () {
 
       global.ApplePaySession.canMakePaymentsWithActiveCard(self.applePayInstance.merchantIdentifier).then(function (canMakePayments) {
         if (!canMakePayments) {
-          self.model.reportError('applePayActiveCardError');
+          if (isProduction) {
+            self.model.reportError('applePayActiveCardError');
+          } else {
+            console.error('Could not find an active card. This may be because your Apple Pay Session was created in the Sandbox environment and your iCloud account is a production account. Log in to a Sandbox iCloud account to test this flow. If you are already logged into an iCloud Sandbox account, then add a card to your wallet.'); // eslint-disable-line no-console
+            self.model.reportError('developerError');
+          }
         }
       });
     });

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -170,7 +170,7 @@ describe('ApplePayView', function () {
       this.view.initialize().then(function () {
         this.view.model.reportError = function (err) {
           expect(err).to.equal('developerError');
-          expect(console.error).to.be.calledWith('Could not find an active card. This may be because your Apple Pay Session was created in the Sandbox environment and your iCloud account is a production account. Log in to a Sandbox iCloud account to test this flow. If you are already logged into an iCloud Sandbox account, then add a card to your wallet.'); // eslint-disable-line no-console
+          expect(console.error).to.be.calledWith('Could not find an active card. This may be because you\'re using a production iCloud account in a sandbox Apple Pay Session. Log in to a Sandbox iCloud account to test this flow, and add a card to your wallet. For additional assistance, visit  https://help.braintreepayments.com'); // eslint-disable-line no-console
           done();
         };
         this.view.model.changeActivePaymentView(this.view.ID);


### PR DESCRIPTION
closes #522

### Summary

A very common complaint is merchants seeing a `Add a supported card to your Apple Pay wallet.` on their Drop-in sandbox integration because they have a production iCloud account. This changes the error to a generic developer error when run not in production with a notice to check the console for more details.

There's no way for us to tell precisely if their is an environment mismatch, but I think this will catch most of the issues in sandbox.

Happy to adjust the wording of the console message.

### Checklist

- [x] Added a changelog entry