### PR TITLE
Automatically disable future funding sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ unreleased
   - Google Pay: Add support for `isNetworkTokenized` param in `parseResponse` method
   - Card Form: Fix issue where pasting a card number over an Amex number could cut off the last digit
   - PayPal: Add support for shipping options (see https://braintree.github.io/braintree-web/current/PayPalCheckout.html#createPayment)
+- Prevent non-PayPal funding sources from appearing in the PayPal views
 
 1.20.4
 ------

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -72,14 +72,22 @@ BasePayPalView.prototype.initialize = function () {
       self.paypalConfiguration.locale = locale;
       checkoutJSConfiguration.locale = locale;
     }
+    checkoutJSConfiguration.funding = {
+      disallowed: []
+    };
+
+    Object.keys(global.paypal.FUNDING).forEach(function (key) {
+      if (key === 'PAYPAL' || key === 'CREDIT') {
+        return;
+      }
+      checkoutJSConfiguration.funding.disallowed.push(global.paypal.FUNDING[key]);
+    });
 
     if (isCredit) {
       buttonSelector = '[data-braintree-id="paypal-credit-button"]';
       checkoutJSConfiguration.style.label = 'credit';
     } else {
-      checkoutJSConfiguration.funding = {
-        disallowed: [global.paypal.FUNDING.CREDIT]
-      };
+      checkoutJSConfiguration.funding.disallowed.push(global.paypal.FUNDING.CREDIT);
     }
 
     return global.paypal.Button.render(checkoutJSConfiguration, buttonSelector).then(function () {

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -23,6 +23,9 @@ describe('BasePayPalView', function () {
       },
       setup: this.sandbox.stub(),
       FUNDING: {
+        FOO: 'foo',
+        VENMO: 'venmo',
+        PAYPAL: 'paypal',
         CREDIT: 'credit'
       }
     };
@@ -197,27 +200,36 @@ describe('BasePayPalView', function () {
       }.bind(this));
     });
 
-    it('dissallows credit option for PayPal', function () {
+    it('dissallows all non-paypal payment methods', function () {
       this.view.model.merchantConfiguration.paypal = this.view.model.merchantConfiguration.paypal;
       this.view._isPayPalCredit = false;
 
       return this.view.initialize().then(function () {
         expect(this.paypal.Button.render).to.be.calledWithMatch({
           funding: {
-            disallowed: ['credit']
+            disallowed: [
+              'foo',
+              'venmo',
+              'credit'
+            ]
           }
         });
       }.bind(this));
     });
 
-    it('does not include funding param for PayPal credit', function () {
+    it('dissallows all funcing but credit for paypal credit', function () {
       this.view.model.merchantConfiguration.paypalCredit = this.view.model.merchantConfiguration.paypal;
       this.view._isPayPalCredit = true;
 
       return this.view.initialize().then(function () {
-        var renderOptions = this.paypal.Button.render.args[0][0];
-
-        expect(renderOptions.funding).to.not.exist;
+        expect(this.paypal.Button.render).to.be.calledWithMatch({
+          funding: {
+            disallowed: [
+              'foo',
+              'venmo'
+            ]
+          }
+        });
       }.bind(this));
     });
 


### PR DESCRIPTION
### Summary

Prevents non-bt allowed payment buttons from auto-appearing in the PayPal views.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
