### PR TITLE
Emit requestable event whenever a saved payment method is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Fix issue where payment requestable event would not fire when switching between vaulted payment methods (#499)
+
 1.22.0
 ------
 - Update braintree-web to v3.57.0

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -142,7 +142,8 @@ DropinModel.prototype.confirmPaymentMethodDeletion = function (paymentMethod) {
 
 DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
   var requestableStateHasNotChanged = this.isPaymentMethodRequestable() === options.isRequestable;
-  var typeHasNotChanged = options.type === this._paymentMethodRequestableType;
+  var nonce = options.selectedPaymentMethod && options.selectedPaymentMethod.nonce;
+  var nonceHasNotChanged = nonce === this._paymentMethodRequestableNonce;
 
   if (!this._setupComplete) {
     // don't emit event until after Drop-in is fully set up
@@ -152,7 +153,7 @@ DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
     return false;
   }
 
-  if (requestableStateHasNotChanged && (!options.isRequestable || typeHasNotChanged)) {
+  if (requestableStateHasNotChanged && (!options.isRequestable || nonceHasNotChanged)) {
     return false;
   }
 
@@ -169,9 +170,9 @@ DropinModel.prototype.setPaymentMethodRequestable = function (options) {
   this._paymentMethodIsRequestable = options.isRequestable;
 
   if (options.isRequestable) {
-    this._paymentMethodRequestableType = options.type;
+    this._paymentMethodRequestableNonce = options.selectedPaymentMethod && options.selectedPaymentMethod.nonce;
   } else {
-    delete this._paymentMethodRequestableType;
+    delete this._paymentMethodRequestableNonce;
   }
 
   if (!shouldEmitEvent) {

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -778,7 +778,7 @@ describe('DropinModel', function () {
       expect(this.model._emit).to.be.calledWith('noPaymentMethodRequestable');
     });
 
-    it('does not emit when isRequestable state and type state does not change', function () {
+    it('does not emit when isRequestable state and nonce does not change', function () {
       this.model._paymentMethodIsRequestable = false;
       this.model.setPaymentMethodRequestable({
         isRequestable: false
@@ -787,16 +787,19 @@ describe('DropinModel', function () {
       expect(this.model._emit).to.not.be.called;
 
       this.model._paymentMethodIsRequestable = true;
-      this.model._paymentMethodRequestableType = 'TYPE';
+      this.model._paymentMethodRequestableNonce = 'fake-nonce';
       this.model.setPaymentMethodRequestable({
         isRequestable: true,
+        selectedPaymentMethod: {
+          nonce: 'fake-nonce'
+        },
         type: 'TYPE'
       });
 
       expect(this.model._emit).to.not.be.called;
     });
 
-    it('does not emit when isRequestable state is false and type has changed', function () {
+    it('does not emit when isRequestable state is false and nonce has changed', function () {
       this.model._paymentMethodIsRequestable = false;
       this.model.setPaymentMethodRequestable({
         isRequestable: false
@@ -804,38 +807,47 @@ describe('DropinModel', function () {
 
       expect(this.model._emit).to.not.be.called;
 
-      this.model._paymentMethodRequestableType = 'TYPE';
+      this.model._paymentMethodRequestableNonce = 'old-fake-nonce';
       this.model.setPaymentMethodRequestable({
         isRequestable: false,
-        type: 'ANOTHER_TYPE'
+        type: 'TYPE',
+        selectedPaymentMethod: {
+          nonce: 'fake-nonce'
+        }
       });
 
       expect(this.model._emit).to.not.be.called;
     });
 
-    it('does emit when isRequestable state has not changed, but type state does', function () {
+    it('does emit when isRequestable state has not changed, but nonce state does', function () {
       this.model._paymentMethodIsRequestable = true;
-      this.model._paymentMethodRequestableType = 'TYPE';
+      this.model._paymentMethodRequestableNonce = 'old-fake-nonce';
       this.model.setPaymentMethodRequestable({
         isRequestable: true,
-        type: 'ANOTHER_TYPE'
+        type: 'TYPE',
+        selectedPaymentMethod: {
+          nonce: 'fake-nonce'
+        }
       });
 
       expect(this.model._emit).to.be.calledOnce;
       expect(this.model._emit).to.be.calledWith('paymentMethodRequestable', {
-        type: 'ANOTHER_TYPE',
-        paymentMethodIsSelected: false
+        type: 'TYPE',
+        paymentMethodIsSelected: true
       });
     });
 
-    it('ignores type if isRequestable is false', function () {
-      this.model._paymentMethodRequestableType = 'SOMETHING';
+    it('ignores nonce if isRequestable is false', function () {
+      this.model._paymentMethodRequestableNonce = 'SOMETHING';
       this.model.setPaymentMethodRequestable({
         isRequestable: false,
-        type: 'SOME_TYPE'
+        type: 'SOME_TYPE',
+        selectedPaymentMethod: {
+          nonce: 'fake-nonce'
+        }
       });
 
-      expect(this.model._paymentMethodRequestableType).to.not.exist;
+      expect(this.model._paymentMethodRequestableNonce).to.not.exist;
     });
 
     it('includes the paymentMethodIsSelected as true if Drop-in displays a selected payment method', function () {


### PR DESCRIPTION
### Summary

Currently, if a customer clicks on a saved payment method, the payment method requestable event will only fire if the customer switches from one type of payment method to another. This PR changes it so that it fires when the nonce changes from one to another.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
