### PR TITLE
Add 3DS support for non-network tokenized Google Pay cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 unreleased
 ----------
+- Add 3DS support for non-network tokenized Google Pay cards
 - Update braintree-web to v3.62.1
 
 1.22.1

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -97,6 +97,8 @@ HAS_RAW_PAYMENT_DATA[constants.paymentMethodTypes.applePay] = true;
  * @property {string} details.cardType Type of card, ex: Visa, Mastercard.
  * @property {string} details.lastFour The last 4 digits of the card.
  * @property {string} details.lastTwo The last 2 digits of the card.
+ * @property {boolean} details.isNetworkTokenized True if the card is network tokenized.
+ * @property {string} details.bin First six digits of card number.
  * @property {external:GooglePayPaymentData} details.rawPaymentData The raw response back from the Google Pay flow, which includes shipping address, phone and email if passed in as required parameters.
  * @property {string} type The payment method type, always `AndroidPayCard` when the method requested is a Google Pay Card.
  * @property {object} binData Information about the card based on the bin. Documented {@link Dropin~binData|here}.
@@ -697,7 +699,10 @@ Dropin.prototype.requestPaymentMethod = function (options) {
   options = options || {};
 
   return this._mainView.requestPaymentMethod().then(function (payload) {
-    if (self._threeDSecure && payload.type === constants.paymentMethodTypes.card && payload.liabilityShifted == null) {
+    if (self._threeDSecure &&
+      (payload.type === constants.paymentMethodTypes.card ||
+      (payload.type === constants.paymentMethodTypes.googlePay && payload.details.isNetworkTokenized === false)) &&
+      payload.liabilityShifted == null) {
       self._mainView.showLoadingIndicator();
 
       return self._threeDSecure.verify(payload, options.threeDSecure).then(function (newPayload) {


### PR DESCRIPTION
### Summary
Runs 3DS verification for non-network tokenized Google Pay cards if 3DS is enabled as well.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@billwerges 
@demerino 