### PR TITLE
Add `threeDSecureInfo` to 3ds payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Add 3DS support for non-network tokenized Google Pay cards
+- Add `threeDSecureInfo` to 3DS payload in `requestPaymentMethod`
 - Update braintree-web to v3.63.0
 
 1.22.1

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -54,6 +54,7 @@ HAS_RAW_PAYMENT_DATA[constants.paymentMethodTypes.applePay] = true;
  * @property {?string} deviceData If data collector is configured, the device data property to be used when making a transaction.
  * @property {?boolean} liabilityShifted If 3D Secure is configured, whether or not liability did shift.
  * @property {?boolean} liabilityShiftPossible If 3D Secure is configured, whether or not liability shift is possible.
+ * @property {?object} threeDSecureInfo If 3D Secure is configured, the `threeDSecureInfo` documented in the [Three D Secure client reference](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/ThreeDSecure.html#~verifyPayload)
  */
 
 /**
@@ -706,6 +707,7 @@ Dropin.prototype.requestPaymentMethod = function (options) {
         payload.nonce = newPayload.nonce;
         payload.liabilityShifted = newPayload.liabilityShifted;
         payload.liabilityShiftPossible = newPayload.liabilityShiftPossible;
+        payload.threeDSecureInfo = newPayload.threeDSecureInfo;
 
         self._mainView.hideLoadingIndicator();
 

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1400,7 +1400,10 @@ describe('Dropin', () => {
           verify: jest.fn().mockResolvedValue({
             nonce: 'new-nonce',
             liabilityShifted: true,
-            liabilityShiftPossible: true
+            liabilityShiftPossible: true,
+            threeDSecureInfo: {
+              threeDSecureAuthenticationId: 'id'
+            }
           })
         };
 
@@ -1411,6 +1414,7 @@ describe('Dropin', () => {
           expect(fakePayload.nonce).toBe('new-nonce');
           expect(fakePayload.liabilityShifted).toBe(true);
           expect(fakePayload.liabilityShiftPossible).toBe(true);
+          expect(fakePayload.threeDSecureInfo.threeDSecureAuthenticationId).toBe('id');
 
           done();
         });


### PR DESCRIPTION
### Summary

Closes https://github.com/braintree/braintree-web-drop-in/issues/635

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
