### PR TITLE
Fix issue where 3ds info was not being passed in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ unreleased
 - Update @braintree/class-list to v0.2.0
 - Update @braintree/event-emitter to v0.4.0
 - Update @braintree/wrap-promise to v2.1.0
+- Fix issue where 3ds info was not being passed on in `requestPaymentMethod` payload
 
 1.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ unreleased
 - Update @braintree/class-list to v0.2.0
 - Update @braintree/event-emitter to v0.4.0
 - Update @braintree/wrap-promise to v2.1.0
-- Fix issue where 3ds info was not being passed on in `requestPaymentMethod` payload
+- Fix issue where `threeDSecureInfo` was not included in `requestPaymentMethod` payload
 
 1.23.0
 ------

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -866,6 +866,10 @@ function formatPaymentMethodPayload(paymentMethod) {
     formattedPaymentMethod.liabilityShiftPossible = paymentMethod.liabilityShiftPossible;
   }
 
+  if (paymentMethod.threeDSecureInfo) {
+    formattedPaymentMethod.threeDSecureInfo = paymentMethod.threeDSecureInfo;
+  }
+
   if (paymentMethod.deviceData) {
     formattedPaymentMethod.deviceData = paymentMethod.deviceData;
   }

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1411,10 +1411,9 @@ describe('Dropin', () => {
           expect(payload.nonce).toBe('new-nonce');
           expect(payload.liabilityShifted).toBe(true);
           expect(payload.liabilityShiftPossible).toBe(true);
-          expect(fakePayload.nonce).toBe('new-nonce');
-          expect(fakePayload.liabilityShifted).toBe(true);
-          expect(fakePayload.liabilityShiftPossible).toBe(true);
-          expect(fakePayload.threeDSecureInfo.threeDSecureAuthenticationId).toBe('id');
+          expect(payload.liabilityShifted).toBe(true);
+          expect(payload.liabilityShiftPossible).toBe(true);
+          expect(payload.threeDSecureInfo.threeDSecureAuthenticationId).toBe('id');
 
           done();
         });


### PR DESCRIPTION
### Summary

We failed to actually send along the 3ds info in the request payment payload 😨 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
