### PR TITLE
Add `showDefaultPaymentMethodFirst` option to create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Fix issue where payment method text may be clipped
-- Add ability to let the Braintree API decide which payment method to show first (typically, the last payment method added to the customer) instead of showing the default payment method first
+- Add ability to let the Braintree API decide which payment method to show first (typically, the last payment method added to the customer) instead of showing the payment method designated as the customer's default in the Braintree control panel
   ```js
   braintree.dropin.create({
     // other config options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 unreleased
 ----------
 - Fix issue where payment method text may be clipped
+- Add ability to let the Braintree API decide which payment method to show first (typically, the last payment method added to the customer) instead of showing the default payment method first
+  ```js
+  braintree.dropin.create({
+    // other config options
+    showDefaultPaymentMethodFirst: false
+  });
+  ```
 
 1.25.0
 ------

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -301,7 +301,7 @@ DropinModel.prototype.getVaultedPaymentMethods = function () {
   }
 
   return self._vaultManager.fetchPaymentMethods({
-    defaultFirst: true
+    defaultFirst: this.merchantConfiguration.showDefaultPaymentMethodFirst !== false
   }).then(function (paymentMethods) {
     return self._getSupportedPaymentMethods(paymentMethods).map(function (paymentMethod) {
       paymentMethod.vaulted = true;

--- a/src/index.js
+++ b/src/index.js
@@ -267,6 +267,8 @@ var VERSION = '__VERSION__';
  *
  * @param {boolean} [options.preselectVaultedPaymentMethod=true] Whether or not to initialize Drop-in with a vaulted payment method pre-selected. Only applicable when using a [client token with a customer id](https://developers.braintreepayments.com/reference/request/client-token/generate/#customer_id) and a customer with saved payment methods.
  *
+ * @param {boolean} [options.showDefaultPaymentMethodFirst=true] When `true` or left out, the customer's default payment method will be displayed first in the list of vaulted payment methods. When `false`, the Braintree API will determine which payment method to display first, typically the latest payment method added to the customer. Only applicable when using a [client token with a customer id](https://developers.braintreepayments.com/reference/request/client-token/generate/#customer_id) and a customer with saved payment methods.
+ *
  * @param {function} [callback] The second argument, `data`, is the {@link Dropin} instance. Returns a promise if no callback is provided.
  * @returns {(void|Promise)} Returns a promise if no callback is provided.
  * @example

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -1246,6 +1246,21 @@ describe('DropinModel', () => {
       }
     );
 
+    test(
+      'fetches last used payment method instead of default when configured',
+      () => {
+        testContext.model.merchantConfiguration.showDefaultPaymentMethodFirst = false;
+        testContext.model.isGuestCheckout = false;
+        testContext.vaultManager.fetchPaymentMethods.mockResolvedValue([]);
+
+        return testContext.model.getVaultedPaymentMethods().then(() => {
+          expect(testContext.vaultManager.fetchPaymentMethods).toBeCalledWith({
+            defaultFirst: false
+          });
+        });
+      }
+    );
+
     test('only resolves supported payment method types', () => {
       testContext.model.isGuestCheckout = false;
       testContext.vaultManager.fetchPaymentMethods.mockResolvedValue([{


### PR DESCRIPTION
closes #652

### Summary

Allows whether to show the default payment method first when displaying vaulted payment methods to be configured.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
