### PR TITLE
Fixup apple pay usage of canMakePaymentsWithActiveCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ unreleased
     showDefaultPaymentMethodFirst: false
   });
   ```
+- Apple Pay
+  - Fix issue where Apple Pay view was using `canMakePaymentsWithActiveCard` incorrectly
 
 1.25.0
 ------

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -20,7 +20,6 @@ ApplePayView.ID = ApplePayView.prototype.ID = paymentOptionIDs.applePay;
 
 ApplePayView.prototype.initialize = function () {
   var self = this;
-  var isProduction = self.client.getConfiguration().gatewayConfiguration.environment === 'production';
 
   self.applePayConfiguration = assign({}, self.model.merchantConfiguration.applePay);
   self.applePaySessionVersion = self.applePayConfiguration.applePaySessionVersion || DEFAULT_APPLE_PAY_SESSION_VERSION;
@@ -33,23 +32,6 @@ ApplePayView.prototype.initialize = function () {
     var buttonDiv = self.getElementById('apple-pay-button');
 
     self.applePayInstance = applePayInstance;
-
-    self.model.on('changeActivePaymentView', function (paymentViewID) {
-      if (paymentViewID !== self.ID) {
-        return;
-      }
-
-      global.ApplePaySession.canMakePaymentsWithActiveCard(self.applePayInstance.merchantIdentifier).then(function (canMakePayments) {
-        if (!canMakePayments) {
-          if (isProduction) {
-            self.model.reportError('applePayActiveCardError');
-          } else {
-            console.error('Could not find an active card. This may be because you\'re using a production iCloud account in a sandbox Apple Pay Session. Log in to a Sandbox iCloud account to test this flow, and add a card to your wallet. For additional assistance, visit  https://help.braintreepayments.com'); // eslint-disable-line no-console
-            self.model.reportError('developerError');
-          }
-        }
-      });
-    });
 
     buttonDiv.onclick = self._showPaymentSheet.bind(self);
     buttonDiv.style['-apple-pay-button-style'] = self.model.merchantConfiguration.applePay.buttonStyle || 'black';

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -34,7 +34,6 @@ describe('ApplePayView', () => {
       global.ApplePaySession = jest.fn().mockReturnValue(testContext.fakeApplePaySession);
       global.ApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
       global.ApplePaySession.supportsVersion = jest.fn().mockReturnValue(true);
-      global.ApplePaySession.canMakePaymentsWithActiveCard = jest.fn().mockResolvedValue(true);
       global.ApplePaySession.STATUS_FAILURE = 'failure';
       global.ApplePaySession.STATUS_SUCCESS = 'success';
       testContext.div.innerHTML = mainHTML;
@@ -137,60 +136,6 @@ describe('ApplePayView', () => {
           }));
 
           expect(error.message).toBe(fakeError.message);
-        });
-      }
-    );
-
-    test(
-      'calls canMakePaymentsWithActiveCard with merchantIdentifier when active payment view is changed to Apple Pay',
-      () => {
-        return testContext.view.initialize().then(() => {
-          testContext.view.model.changeActivePaymentView(testContext.view.ID);
-
-          expect(global.ApplePaySession.canMakePaymentsWithActiveCard).toBeCalledTimes(1);
-          expect(global.ApplePaySession.canMakePaymentsWithActiveCard).toBeCalledWith(testContext.fakeApplePayInstance.merchantIdentifier);
-        });
-      }
-    );
-
-    test(
-      'reports error when canMakePaymentsWithActiveCard returns false in production mode',
-      done => {
-        const configuration = fake.configuration();
-
-        configuration.gatewayConfiguration.environment = 'production';
-        testContext.fakeClient.getConfiguration.mockReturnValue(configuration);
-
-        global.ApplePaySession.canMakePaymentsWithActiveCard = jest.fn().mockResolvedValue(false);
-
-        testContext.view.initialize().then(() => {
-          testContext.view.model.reportError = err => {
-            expect(err).toBe('applePayActiveCardError');
-            done();
-          };
-          testContext.view.model.changeActivePaymentView(testContext.view.ID);
-        });
-      }
-    );
-
-    test(
-      'reports developer error when canMakePaymentsWithActiveCard returns false in sandbox mode',
-      done => {
-        const configuration = fake.configuration();
-
-        configuration.gatewayConfiguration.environment = 'sandbox';
-        testContext.fakeClient.getConfiguration.mockReturnValue(configuration);
-
-        jest.spyOn(console, 'error').mockImplementation();
-        global.ApplePaySession.canMakePaymentsWithActiveCard = jest.fn().mockResolvedValue(false);
-
-        testContext.view.initialize().then(() => {
-          testContext.view.model.reportError = err => {
-            expect(err).toBe('developerError');
-            expect(console.error).toBeCalledWith('Could not find an active card. This may be because you\'re using a production iCloud account in a sandbox Apple Pay Session. Log in to a Sandbox iCloud account to test this flow, and add a card to your wallet. For additional assistance, visit  https://help.braintreepayments.com'); // eslint-disable-line no-console
-            done();
-          };
-          testContext.view.model.changeActivePaymentView(testContext.view.ID);
         });
       }
     );


### PR DESCRIPTION
### Summary

The requirements for the `canMakePaymentsWithActiveCard` require Apple Pay to be the only method positioned if it resolves with true. See https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778000-canmakepaymentswithactivecard

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
