### PR TITLE
fix: issue where PayPal button could render in the wrong drop-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ unreleased
   ```
 - Apple Pay
   - Fix issue where Apple Pay view was using `canMakePaymentsWithActiveCard` incorrectly
+- PayPal
+  - Fix issue where PayPal buttons would not render correctly when multiple Drop-in instances were loaded (closes #590)
 
 1.25.0
 ------

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -30,6 +30,7 @@ BasePayPalView.prototype.initialize = function () {
   var self = this;
   var paypalType = isCredit ? 'paypalCredit' : 'paypal';
   var paypalConfiguration = this.model.merchantConfiguration[paypalType];
+  var dropinWrapperId = '#braintree--dropin__' + this.model.componentID;
 
   this.paypalConfiguration = assign({}, paypalConfiguration);
 
@@ -89,6 +90,8 @@ BasePayPalView.prototype.initialize = function () {
     } else {
       checkoutJSConfiguration.funding.disallowed.push(global.paypal.FUNDING.CREDIT);
     }
+
+    buttonSelector = dropinWrapperId + ' ' + buttonSelector;
 
     return global.paypal.Button.render(checkoutJSConfiguration, buttonSelector).then(function () {
       self.model.asyncDependencyReady();

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -150,7 +150,10 @@ describe('BasePayPalView', () => {
     test('calls paypal.Button.render', () => {
       return testContext.view.initialize().then(() => {
         expect(testContext.paypal.Button.render).toBeCalledTimes(1);
-        expect(testContext.paypal.Button.render).toBeCalledWith(expect.any(Object), '[data-braintree-id="paypal-button"]');
+        expect(testContext.paypal.Button.render).toBeCalledWith(
+          expect.any(Object),
+          expect.stringMatching(/#braintree--dropin__.*\[data-braintree-id="paypal-button"\]/)
+        );
       });
     });
 
@@ -697,7 +700,10 @@ describe('BasePayPalView', () => {
 
       test('uses the PayPal button selector', () => {
         return testContext.view.initialize().then(() => {
-          expect(testContext.paypal.Button.render).toBeCalledWith(expect.any(Object), '[data-braintree-id="paypal-button"]');
+          expect(testContext.paypal.Button.render).toBeCalledWith(
+            expect.any(Object),
+            expect.stringMatching(/#braintree--dropin__.*\[data-braintree-id="paypal-button"\]/)
+          );
         });
       });
     });
@@ -766,7 +772,10 @@ describe('BasePayPalView', () => {
         testContext.view._isPayPalCredit = true;
 
         return testContext.view.initialize().then(() => {
-          expect(testContext.paypal.Button.render).toBeCalledWith(expect.any(Object), '[data-braintree-id="paypal-credit-button"]');
+          expect(testContext.paypal.Button.render).toBeCalledWith(
+            expect.any(Object),
+            expect.stringMatching(/#braintree--dropin__.*\[data-braintree-id="paypal-credit-button"\]/)
+          );
         });
       });
 


### PR DESCRIPTION
closes #590

### Summary

We weren't being specific enough for the PayPal SDK about where to render the paypal buttons. This scopes them to the containing div.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
