### PR TITLE
feat: add support for Venmo Desktop

### DIFF
--- a/src/views/payment-sheet-views/venmo-view.js
+++ b/src/views/payment-sheet-views/venmo-view.js
@@ -70,7 +70,7 @@ VenmoView.prototype._isIgnorableError = function (error) {
   // customer cancels the flow in the app
   // we don't emit an error because the customer
   // initiated that action
-  return error.code === 'VENMO_APP_CANCELED';
+  return error.code === 'VENMO_APP_CANCELED' || error.code === 'VENMO_DESKTOP_CANCELED';
 };
 
 VenmoView.isEnabled = function (options) {

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -144,6 +144,9 @@
         totalPrice: '19.99'
       }
     },
+    venmo: {
+      allowDesktop: true
+    },
     vaultManager: true
   };
   var dropinInstance;

--- a/test/unit/views/payment-sheet-views/venmo-view.js
+++ b/test/unit/views/payment-sheet-views/venmo-view.js
@@ -162,6 +162,24 @@ describe('VenmoView', () => {
     );
 
     test(
+      'does not report app switch error for VENMO_DESKTOP_CANCELLED error',
+      () => {
+        const error = new Error('failure');
+
+        error.code = 'VENMO_DESKTOP_CANCELED';
+
+        testContext.fakeVenmoInstance.hasTokenizationResult.mockReturnValue(true);
+        testContext.fakeVenmoInstance.tokenize.mockRejectedValue(error);
+
+        return testContext.view.initialize().then(() => {
+          expect(testContext.fakeVenmoInstance.tokenize).toBeCalledTimes(1);
+          expect(testContext.model.reportAppSwitchError).not.toBeCalled();
+          expect(testContext.model.reportAppSwitchPayload).not.toBeCalled();
+        });
+      }
+    );
+
+    test(
       'calls asyncDependencyFailed when Venmo component creation fails',
       () => {
         const fakeError = new Error('A_FAKE_ERROR');


### PR DESCRIPTION
### Summary

* Adds `allowDesktop` configuration to venmo in Drop-in demo.
* Handles a customer cancelling the desktop flow

### Checklist

- [ ] ~~Added a changelog entry~~ Should we add this to the changelog?

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
