### PR TITLE
fix: issue with passing custom button option to Google Pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Google Pay
+  - Fix issue where passing custom button option would caused a developer error in the console (#701)
+
 1.26.1
 ------
 - Update braintree-web to v3.73.1

--- a/src/views/payment-sheet-views/google-pay-view.js
+++ b/src/views/payment-sheet-views/google-pay-view.js
@@ -25,9 +25,6 @@ GooglePayView.prototype.initialize = function () {
   googlePayVersion = self.googlePayConfiguration.googlePayVersion;
   merchantId = self.googlePayConfiguration.merchantId;
 
-  delete self.googlePayConfiguration.googlePayVersion;
-  delete self.googlePayConfiguration.merchantId;
-
   buttonOptions = assign({
     buttonType: 'short'
   }, self.googlePayConfiguration.button, {
@@ -41,6 +38,10 @@ GooglePayView.prototype.initialize = function () {
       });
     }
   });
+
+  delete self.googlePayConfiguration.googlePayVersion;
+  delete self.googlePayConfiguration.merchantId;
+  delete self.googlePayConfiguration.button;
 
   self.model.asyncDependencyStarting();
 

--- a/test/unit/views/payment-sheet-views/google-pay-view.js
+++ b/test/unit/views/payment-sheet-views/google-pay-view.js
@@ -304,6 +304,30 @@ describe('GooglePayView', () => {
       });
     });
 
+    test('does not pass along button configuration to createPaymentDataRequest', async () => {
+      testContext.model.merchantConfiguration.googlePay.button = {
+        buttonType: 'long',
+        buttonColor: 'white'
+      };
+      const view = new GooglePayView(testContext.googlePayViewOptions);
+
+      jest.spyOn(view.model, 'addPaymentMethod').mockImplementation();
+      jest.spyOn(view.model, 'reportError').mockImplementation();
+
+      await view.initialize();
+
+      await view.tokenize();
+
+      expect(testContext.fakeGooglePayInstance.createPaymentDataRequest).toBeCalledTimes(1);
+      expect(testContext.fakeGooglePayInstance.createPaymentDataRequest).toBeCalledWith({
+        transactionInfo: {
+          currencyCode: 'USD',
+          totalPriceStatus: 'FINAL',
+          totalPrice: '100.00'
+        }
+      });
+    });
+
     test('calls loadPaymentData with paymentDataRequest', () => {
       return testContext.view.tokenize().then(() => {
         expect(testContext.FakePaymentClient.prototype.loadPaymentData).toBeCalledTimes(1);


### PR DESCRIPTION
closes #701

### Summary

I _think_ Google Pay started validating the options that get passed in. Removing it from the configuration should be enough to fix the issue.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 
