### PR TITLE
Fix race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Fix issue where Drop-in may error or not set up completely due to dependency setup race condition (#700)
+- Fix issue where Drop-in may report it is ready even though no payment options are actually available
 - Google Pay
   - Fix issue where passing custom button option would caused a developer error in the console (#701)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 unreleased
 ----------
+- Fix issue where Drop-in may error or not set up completely due to dependency setup race condition (#700)
 - Google Pay
   - Fix issue where passing custom button option would caused a developer error in the console (#701)
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,12 @@ module.exports = {
     unionpay: 'UnionPay',
     maestro: 'Maestro'
   },
+  dependencySetupStates: {
+    DONE: 'done',
+    FAILED: 'failed',
+    INITIALIZING: 'initializing',
+    NOT_ENABLED: 'not-enabled'
+  },
   errors: {
     NO_PAYMENT_METHOD_ERROR: 'No payment method is available.',
     DEVELOPER_MISCONFIGURATION_MESSAGE: 'Developer Error: Something went wrong. Check the console for details.'

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -66,7 +66,7 @@ DropinModel.prototype.initialize = function () {
   var dependencyReadyInterval = setInterval(function () {
     var ready = true;
 
-    ASYNC_DEPENDENCIES.forEach(function (dep) {
+    Object.keys(self.dependencyStates).forEach(function (dep) {
       if (self.dependencyStates[dep] === dependencySetupStates.INITIALIZING) {
         ready = false;
       }

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -253,9 +253,6 @@ DropinModel.prototype.hasAtLeastOneAvailablePaymentOption = function () {
   var self = this;
   var i;
 
-  console.log(this.supportedPaymentOptions);
-  console.log(self.dependencyStates);
-
   for (i = 0; i < this.supportedPaymentOptions.length; i++) {
     if (self.dependencyStates[this.supportedPaymentOptions[i]] === dependencySetupStates.DONE) {
       return true;

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -41,8 +41,12 @@ function DropinModel(options) {
 
     return total;
   }, {});
+  // card is on by default, so we need to set it's state to INITIALIZING
+  // unless the merchant has specifically opted out of using the card form
+  if (options.merchantConfiguration.card !== false) {
+    this.dependencyStates.card = dependencySetupStates.INITIALIZING;
+  }
 
-  this.dependencySuccessCount = 0;
   this.failedDependencies = {};
   this._options = options;
   this._setupComplete = false;
@@ -245,8 +249,23 @@ DropinModel.prototype.reportAppSwitchError = function (sheetId, error) {
   };
 };
 
+DropinModel.prototype.hasAtLeastOneAvailablePaymentOption = function () {
+  var self = this;
+  var i;
+
+  console.log(this.supportedPaymentOptions);
+  console.log(self.dependencyStates);
+
+  for (i = 0; i < this.supportedPaymentOptions.length; i++) {
+    if (self.dependencyStates[this.supportedPaymentOptions[i]] === dependencySetupStates.DONE) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 DropinModel.prototype.asyncDependencyReady = function (key) {
-  this.dependencySuccessCount++;
   this.dependencyStates[key] = dependencySetupStates.DONE;
 };
 

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -597,11 +597,10 @@ Dropin.prototype._setUpDataCollector = function () {
   var self = this;
   var config = assign({}, self._merchantConfiguration.dataCollector, {client: self._client});
 
-  this._model.asyncDependencyStarting();
   this._dataCollector = new DataCollector(config);
 
   this._dataCollector.initialize().then(function () {
-    self._model.asyncDependencyReady();
+    self._model.asyncDependencyReady('dataCollector');
   }).catch(function (err) {
     self._model.cancelInitialization(new DropinError({
       message: 'Data Collector failed to set up.',
@@ -613,12 +612,10 @@ Dropin.prototype._setUpDataCollector = function () {
 Dropin.prototype._setUpThreeDSecure = function () {
   var self = this;
 
-  this._model.asyncDependencyStarting();
-
   this._threeDSecure = new ThreeDSecure(this._client, this._model);
 
   this._threeDSecure.initialize().then(function () {
-    self._model.asyncDependencyReady();
+    self._model.asyncDependencyReady('threeDSecure');
   }).catch(function (err) {
     self._model.cancelInitialization(new DropinError({
       message: '3D Secure failed to set up.',

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -456,7 +456,7 @@ Dropin.prototype._initialize = function (callback) {
     });
 
     self._model.on('asyncDependenciesReady', function () {
-      if (self._model.dependencySuccessCount >= 1) {
+      if (self._model.hasAtLeastOneAvailablePaymentOption()) {
         analytics.sendEvent(self._client, 'appeared');
         self._disableErroredPaymentMethods();
 

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -26,8 +26,6 @@ ApplePayView.prototype.initialize = function () {
 
   delete self.applePayConfiguration.applePaySessionVersion;
 
-  self.model.asyncDependencyStarting();
-
   return btApplePay.create({client: this.client}).then(function (applePayInstance) {
     var buttonDiv = self.getElementById('apple-pay-button');
 
@@ -36,7 +34,7 @@ ApplePayView.prototype.initialize = function () {
     buttonDiv.onclick = self._showPaymentSheet.bind(self);
     buttonDiv.style['-apple-pay-button-style'] = self.model.merchantConfiguration.applePay.buttonStyle || 'black';
 
-    self.model.asyncDependencyReady();
+    self.model.asyncDependencyReady(ApplePayView.ID);
   }).catch(function (err) {
     self.model.asyncDependencyFailed({
       view: self.ID,

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -34,7 +34,6 @@ BasePayPalView.prototype.initialize = function () {
 
   this.paypalConfiguration = assign({}, paypalConfiguration);
 
-  this.model.asyncDependencyStarting();
   asyncDependencyTimeoutHandler = setTimeout(function () {
     self.model.asyncDependencyFailed({
       view: self.ID,
@@ -94,7 +93,7 @@ BasePayPalView.prototype.initialize = function () {
     buttonSelector = dropinWrapperId + ' ' + buttonSelector;
 
     return global.paypal.Button.render(checkoutJSConfiguration, buttonSelector).then(function () {
-      self.model.asyncDependencyReady();
+      self.model.asyncDependencyReady(paypalType);
       setupComplete = true;
       clearTimeout(asyncDependencyTimeoutHandler);
     });

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -73,8 +73,6 @@ CardView.prototype.initialize = function () {
     this.saveCardInput.checked = false;
   }
 
-  this.model.asyncDependencyStarting();
-
   return hostedFields.create(hfOptions).then(function (hostedFieldsInstance) {
     this.hostedFieldsInstance = hostedFieldsInstance;
     this.hostedFieldsInstance.on('blur', this._onBlurEvent.bind(this));
@@ -89,7 +87,7 @@ CardView.prototype.initialize = function () {
       }.bind(this));
     }.bind(this));
 
-    this.model.asyncDependencyReady();
+    this.model.asyncDependencyReady(CardView.ID);
   }.bind(this)).catch(function (err) {
     this.model.asyncDependencyFailed({
       view: this.ID,

--- a/src/views/payment-sheet-views/google-pay-view.js
+++ b/src/views/payment-sheet-views/google-pay-view.js
@@ -43,8 +43,6 @@ GooglePayView.prototype.initialize = function () {
   delete self.googlePayConfiguration.merchantId;
   delete self.googlePayConfiguration.button;
 
-  self.model.asyncDependencyStarting();
-
   return btGooglePay.create({
     client: self.client,
     googlePayVersion: googlePayVersion,
@@ -57,7 +55,7 @@ GooglePayView.prototype.initialize = function () {
 
     buttonContainer.appendChild(self.paymentsClient.createButton(buttonOptions));
 
-    self.model.asyncDependencyReady();
+    self.model.asyncDependencyReady(GooglePayView.ID);
   }).catch(function (err) {
     self.model.asyncDependencyFailed({
       view: self.ID,

--- a/src/views/payment-sheet-views/venmo-view.js
+++ b/src/views/payment-sheet-views/venmo-view.js
@@ -19,8 +19,6 @@ VenmoView.prototype.initialize = function () {
   var self = this;
   var venmoConfiguration = assign({}, self.model.merchantConfiguration.venmo, {client: this.client});
 
-  self.model.asyncDependencyStarting();
-
   return btVenmo.create(venmoConfiguration).then(function (venmoInstance) {
     self.venmoInstance = venmoInstance;
 
@@ -57,7 +55,7 @@ VenmoView.prototype.initialize = function () {
       });
     });
 
-    self.model.asyncDependencyReady();
+    self.model.asyncDependencyReady(VenmoView.ID);
   }).catch(function (err) {
     self.model.asyncDependencyFailed({
       view: self.ID,

--- a/test/unit/views/payment-methods-view.js
+++ b/test/unit/views/payment-methods-view.js
@@ -153,6 +153,7 @@ describe('PaymentMethodsView', () => {
         model.getVaultedPaymentMethods.mockResolvedValue([{ foo: 'bar' }, fakePaymentMethod]);
 
         return model.initialize().then(() => {
+          model.asyncDependencyReady('card');
           model.changeActivePaymentMethod({ foo: 'bar' });
 
           paymentMethodsViews = new PaymentMethodsView({

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -80,19 +80,12 @@ describe('ApplePayView', () => {
       testContext.view = new ApplePayView(testContext.applePayViewOptions);
     });
 
-    test('starts async dependency', () => {
-      jest.spyOn(testContext.view.model, 'asyncDependencyStarting').mockImplementation();
-
-      return testContext.view.initialize().then(() => {
-        expect(testContext.view.model.asyncDependencyStarting).toBeCalledTimes(1);
-      });
-    });
-
     test('notifies async dependency', () => {
       jest.spyOn(testContext.view.model, 'asyncDependencyReady').mockImplementation();
 
       return testContext.view.initialize().then(() => {
         expect(testContext.view.model.asyncDependencyReady).toBeCalledTimes(1);
+        expect(testContext.view.model.asyncDependencyReady).toBeCalledWith('applePay');
       });
     });
 

--- a/test/unit/views/payment-sheet-views/base-paypal-view.js
+++ b/test/unit/views/payment-sheet-views/base-paypal-view.js
@@ -80,19 +80,24 @@ describe('BasePayPalView', () => {
       testContext.view = new BasePayPalView(testContext.paypalViewOptions);
     });
 
-    test('starts async dependency', () => {
-      jest.spyOn(testContext.view.model, 'asyncDependencyStarting').mockImplementation();
-
-      return testContext.view.initialize().then(() => {
-        expect(testContext.view.model.asyncDependencyStarting).toBeCalledTimes(1);
-      });
-    });
-
-    test('notifies async dependency', () => {
+    test('notifies async dependency ready for paypal', () => {
       jest.spyOn(testContext.view.model, 'asyncDependencyReady').mockImplementation();
 
       return testContext.view.initialize().then(() => {
         expect(testContext.view.model.asyncDependencyReady).toBeCalledTimes(1);
+        expect(testContext.view.model.asyncDependencyReady).toBeCalledWith('paypal');
+      });
+    });
+
+    test('notifies async dependency ready for paypalCredit', () => {
+      jest.spyOn(testContext.view.model, 'asyncDependencyReady').mockImplementation();
+
+      testContext.view.model.merchantConfiguration.paypalCredit = testContext.view.model.merchantConfiguration.paypal;
+      testContext.view._isPayPalCredit = true;
+
+      return testContext.view.initialize().then(() => {
+        expect(testContext.view.model.asyncDependencyReady).toBeCalledTimes(1);
+        expect(testContext.view.model.asyncDependencyReady).toBeCalledWith('paypalCredit');
       });
     });
 
@@ -133,19 +138,6 @@ describe('BasePayPalView', () => {
         });
       }
     );
-
-    test('calls asyncDependencyStarting when initializing', () => {
-      const fakeError = {
-        code: 'A_REAL_ERROR_CODE'
-      };
-
-      PayPalCheckout.create.mockRejectedValue(fakeError);
-
-      jest.spyOn(DropinModel.prototype, 'asyncDependencyStarting').mockImplementation();
-      testContext.view.initialize();
-
-      expect(testContext.view.model.asyncDependencyStarting).toBeCalledTimes(1);
-    });
 
     test('calls paypal.Button.render', () => {
       return testContext.view.initialize().then(() => {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -319,21 +319,6 @@ describe('CardView', () => {
       });
     });
 
-    test('starts async dependency', () => {
-      jest.spyOn(DropinModel.prototype, 'asyncDependencyStarting');
-
-      const view = new CardView({
-        element: cardElement,
-        model: fakeModel,
-        client: fakeClient,
-        strings: strings
-      });
-
-      return view.initialize().then(() => {
-        expect(DropinModel.prototype.asyncDependencyStarting).toBeCalledTimes(1);
-      });
-    });
-
     test(
       'notifies async dependency is ready when Hosted Fields is created',
       () => {
@@ -348,6 +333,7 @@ describe('CardView', () => {
 
         return view.initialize().then(() => {
           expect(DropinModel.prototype.asyncDependencyReady).toBeCalledTimes(1);
+          expect(DropinModel.prototype.asyncDependencyReady).toBeCalledWith('card');
         });
       }
     );

--- a/test/unit/views/payment-sheet-views/google-pay-view.js
+++ b/test/unit/views/payment-sheet-views/google-pay-view.js
@@ -107,19 +107,12 @@ describe('GooglePayView', () => {
       testContext.view = new GooglePayView(testContext.googlePayViewOptions);
     });
 
-    test('starts async dependency', () => {
-      jest.spyOn(testContext.view.model, 'asyncDependencyStarting').mockImplementation();
-
-      return testContext.view.initialize().then(() => {
-        expect(testContext.view.model.asyncDependencyStarting).toBeCalledTimes(1);
-      });
-    });
-
     test('notifies async dependency', () => {
       jest.spyOn(testContext.view.model, 'asyncDependencyReady').mockImplementation();
 
       return testContext.view.initialize().then(() => {
         expect(testContext.view.model.asyncDependencyReady).toBeCalledTimes(1);
+        expect(testContext.view.model.asyncDependencyReady).toBeCalledWith('googlePay');
       });
     });
 

--- a/test/unit/views/payment-sheet-views/venmo-view.js
+++ b/test/unit/views/payment-sheet-views/venmo-view.js
@@ -61,19 +61,12 @@ describe('VenmoView', () => {
       testContext.view = new VenmoView(testContext.venmoViewOptions);
     });
 
-    test('starts async dependency', () => {
-      jest.spyOn(testContext.view.model, 'asyncDependencyStarting').mockImplementation();
-
-      return testContext.view.initialize().then(() => {
-        expect(testContext.view.model.asyncDependencyStarting).toBeCalledTimes(1);
-      });
-    });
-
     test('notifies async dependency', () => {
       jest.spyOn(testContext.view.model, 'asyncDependencyReady').mockImplementation();
 
       return testContext.view.initialize().then(() => {
         expect(testContext.view.model.asyncDependencyReady).toBeCalledTimes(1);
+        expect(testContext.view.model.asyncDependencyReady).toBeCalledWith('venmo');
       });
     });
 


### PR DESCRIPTION
### Summary

The way Drop-in was constructed, it was possible to get into a race condition during set up where some dependencies (payment options, data collector, 3ds, etc) can report that they are ready before others even start setting up, causing Drop-in to attempt to finish the setup too early and fail (or miss some payment options).

This PR lets Drop-in know up front what dependencies it is setting up and periodically checks if all the dependencies have reached a terminal set up state (either done, failed or not enabled).

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 
