### PR TITLE
Previously discussed micro-optimization in race-condition fix

### DIFF
--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -64,16 +64,11 @@ EventEmitter.createChild(DropinModel);
 DropinModel.prototype.initialize = function () {
   var self = this;
   var dependencyReadyInterval = setInterval(function () {
-    var ready = true;
-
-    Object.keys(self.dependencyStates).forEach(function (dep) {
+    for (var dep in self.dependencyStates)
+    {
       if (self.dependencyStates[dep] === dependencySetupStates.INITIALIZING) {
-        ready = false;
+        return;
       }
-    });
-
-    if (!ready) {
-      return;
     }
 
     clearInterval(dependencyReadyInterval);


### PR DESCRIPTION
Finally got around to rebasing my fork, so I can finally pull request the micro-optimization as discussed over here: https://github.com/braintree/braintree-web-drop-in/pull/704#discussion_r588787000

The change eliminates at least 2 function/method calls, reduces the number of times a loop is iterated, and is more compact than the original.