### PR TITLE
fix: correct initialization logic for determining async dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ unreleased
 - Fix issue where card view would not render in a shadow DOM within a shadow DOM
 - Fix issue where Venmo would setup in Firefox for iOS with `allowNewBrowserTab: false` set
 - Improve keyboard navigation
+- Fix bug in initialization process where loading spinner would never resolve (#716)
 
 1.27.0
 ------

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -35,7 +35,7 @@ function DropinModel(options) {
   this.isGuestCheckout = isGuestCheckout(options.client);
 
   this.dependencyStates = ASYNC_DEPENDENCIES.reduce(function (total, dependencyKey) {
-    if (dependencyKey in options.merchantConfiguration) {
+    if (options.merchantConfiguration[dependencyKey]) {
       total[dependencyKey] = dependencySetupStates.INITIALIZING;
     }
 

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -93,6 +93,23 @@ describe('DropinModel', () => {
       expect(model.isInShadowDom).toBe(true);
     });
 
+    test('does not set payment methods as initializing when merchant configuration has falsy values', () => {
+      // eslint-disable-next-line no-undefined
+      testContext.modelOptions.merchantConfiguration.venmo = undefined;
+      testContext.modelOptions.merchantConfiguration.paypalCredit = false;
+      testContext.modelOptions.merchantConfiguration.applePay = '';
+      testContext.modelOptions.merchantConfiguration.googlePay = 0;
+
+      const model = new DropinModel(testContext.modelOptions);
+
+      expect(model.dependencyStates.paypalCredit).toBeFalsy();
+      expect(model.dependencyStates.venmo).toBeFalsy();
+      expect(model.dependencyStates.applePay).toBeFalsy();
+      expect(model.dependencyStates.googlePay).toBeFalsy();
+      expect(model.dependencyStates.card).toBe('initializing');
+      expect(model.dependencyStates.paypal).toBe('initializing');
+    });
+
     describe('isGuestCheckout', () => {
       test('is true when given a tokenization key', () => {
         let model;


### PR DESCRIPTION
closes #716

### Summary

Correct initialization logic for how async dependencies are queued in Drop-in Model.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 
