### PR TITLE
feat: add threeDSecure.cardinalSDKConfig to drop-in create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Add `threeDSecure.cardinalSDKConfig` option to `dropin.create`
+
 1.28.0
 ------
 - Update braintree-web to v3.76.3

--- a/src/index.js
+++ b/src/index.js
@@ -134,10 +134,18 @@ var VERSION = '__VERSION__';
  */
 
 /**
- * @typedef {object} threeDSecureOptions _Deprecated_ If the `threeDSecureOptions` passed into the create call is an object, you may set the `amount` to verify with 3D Secure. However, it's recomended that you pass `true` instead of a configuration object and do all 3D Secure configuration in the {@link Dropin#requestPaymentMethod|requestPaymentMethod options}.
+ * @typedef {object} threeDSecureOptions If the `threeDSecureOptions` passed into the create call is an object, you may set the `amount` to verify with 3D Secure. However, it's recomended that you pass `true` instead of a configuration object and do all 3D Secure configuration in the {@link Dropin#requestPaymentMethod|requestPaymentMethod options}.
  *
  * @param {string} amount The amount to verify with 3D Secure.
  */
+
+/**
+ * @typedef {object} threeDSecureOptions Configuration options to pass when creating the 3D Secure module used in Drop-in.
+ *
+ * @param {options} cardinalSDKConfig A configuration object to adjust the configuration for the underlying Cardinal SDK (Braintree's 3D Secure provider). See [`cardinalSDKConfig` options](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/module-braintree-web_three-d-secure.html#.create) for all options.
+ * @param {string} amount __Deprecated__ The amount to verify with 3D Secure. Set amount in the {@link Dropin#requestPaymentMethod|requestPaymentMethod options} instead.
+ */
+
 
 /** @typedef {object} paypalCreateOptions The configuration options for PayPal and PayPalCredit. For a full list of options see the [PayPal Checkout client reference options](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/PayPalCheckout.html#createPayment).
  *
@@ -263,7 +271,7 @@ var VERSION = '__VERSION__';
  *
  * @param {object|boolean} [options.dataCollector] If `true` is passed, Drop-in will be configured to collect data for use with Advanced Fraud Protection. If collecting data via Kount, pass a [`dataCollectorOptions` object](#~dataCollectorOptions) with `kount: true` instead. If Data Collector is configured and fails to load, Drop-in creation will fail.
  *
- * @param {(boolean|object)} [options.threeDSecure] It's recomended that you pass `true` here to enable 3D Secure and pass the configuration options for 3D Secure into {@link Dropin#requestPaymentMethod|requestPaymentMethod options}.See [`threeDSecureOptions`](#~threeDSecureOptions) for the deprecated create options. If 3D Secure is configured and fails to load, Drop-in creation will fail.
+ * @param {(boolean|object)} [options.threeDSecure] When `true` is passed, the 3D Secure module will be created with a default configuration. See [`threeDSecureOptions`](#~threeDSecureOptions) for additional create options. If 3D Secure is configured and fails to load, Drop-in creation will fail.
  *
  * @param {boolean} [options.vaultManager=false] Whether or not to allow a customer to delete saved payment methods when used with a [client token with a customer id](https://developers.braintreepayments.com/reference/request/client-token/generate/#customer_id). *Note:* Deleting a payment method from Drop-in will permanently delete the payment method, so this option is not recommended for merchants using Braintree's recurring billing system. This feature is not supported in Internet Explorer 9.
  *

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,6 @@ var VERSION = '__VERSION__';
  * @param {string} amount __Deprecated__ The amount to verify with 3D Secure. Set amount in the {@link Dropin#requestPaymentMethod|requestPaymentMethod options} instead.
  */
 
-
 /** @typedef {object} paypalCreateOptions The configuration options for PayPal and PayPalCredit. For a full list of options see the [PayPal Checkout client reference options](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/PayPalCheckout.html#createPayment).
  *
  * @param {string} flow Either `checkout` for a one-time [Checkout with PayPal](https://developers.braintreepayments.com/guides/paypal/checkout-with-paypal/javascript/v3) flow or `vault` for a [Vault flow](https://developers.braintreepayments.com/guides/paypal/vault/javascript/v3). Required when using PayPal or PayPal Credit.

--- a/src/index.js
+++ b/src/index.js
@@ -134,13 +134,7 @@ var VERSION = '__VERSION__';
  */
 
 /**
- * @typedef {object} threeDSecureOptions If the `threeDSecureOptions` passed into the create call is an object, you may set the `amount` to verify with 3D Secure. However, it's recomended that you pass `true` instead of a configuration object and do all 3D Secure configuration in the {@link Dropin#requestPaymentMethod|requestPaymentMethod options}.
- *
- * @param {string} amount The amount to verify with 3D Secure.
- */
-
-/**
- * @typedef {object} threeDSecureOptions Configuration options to pass when creating the 3D Secure module used in Drop-in.
+ * @typedef {object} threeDSecureOptions Configuration options to pass when creating the 3D Secure module used in Drop-in. `amount` for 3D Secure verification can be passed here, but it's recomended that it and all other 3D Secure verification options be passed to the {@link Dropin#requestPaymentMethod|requestPaymentMethod options} instead. Any `cardinalSDKConfig` options must be passed here when creating Drop-in.
  *
  * @param {options} cardinalSDKConfig A configuration object to adjust the configuration for the underlying Cardinal SDK (Braintree's 3D Secure provider). See [`cardinalSDKConfig` options](http://braintree.github.io/braintree-web/{@pkg bt-web-version}/module-braintree-web_three-d-secure.html#.create) for all options.
  * @param {string} amount __Deprecated__ The amount to verify with 3D Secure. Set amount in the {@link Dropin#requestPaymentMethod|requestPaymentMethod options} instead.

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -18,11 +18,16 @@ function ThreeDSecure(client, model) {
 
 ThreeDSecure.prototype.initialize = function () {
   var self = this;
-
-  return threeDSecure.create({
+  var options = {
     client: this._client,
     version: 2
-  }).then(function (instance) {
+  };
+
+  if (this._config.cardinalSDKConfig) {
+    options.cardinalSDKConfig = this._config.cardinalSDKConfig;
+  }
+
+  return threeDSecure.create(options).then(function (instance) {
     self._instance = instance;
 
     PASSTHROUGH_EVENTS.forEach(function (eventName) {

--- a/test/unit/lib/three-d-secure.js
+++ b/test/unit/lib/three-d-secure.js
@@ -65,6 +65,25 @@ describe('ThreeDSecure', () => {
         expect(testContext.model._emit).toBeCalledWith('3ds:authentication-modal-close', { someEvent: 'foo' });
       });
     });
+
+    test('adds cardinalSDKConfig object to the threeDSecure.create call', () => {
+      const client = {};
+
+      testContext.model.merchantConfiguration.threeDSecure = {
+        cardinalSDKConfig: { logging: { level: 'verbose' }}
+      };
+      const tds = new ThreeDSecure(client, testContext.model);
+
+      return tds.initialize().then(() => {
+        expect(threeDSecure.create).toBeCalledTimes(1);
+        expect(threeDSecure.create).toBeCalledWith({
+          client: client,
+          version: 2,
+          cardinalSDKConfig: { logging: { level: 'verbose' }}
+        });
+        expect(tds._instance).toBe(testContext.threeDSecureInstance);
+      });
+    });
   });
 
   describe('verify', () => {


### PR DESCRIPTION
### Summary

Add ability to pass in the `cardinalSDKConfig` object to the `dropin.create` call.

### Checklist

- [ x ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @crookedneighbor 
- @jplukarski 

