### PR TITLE
fix: correct handling for a failed 3ds authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Update braintree-web to v3.76.4
 - Add `threeDSecure.cardinalSDKConfig` option to `dropin.create`
+- Fix issue where Drop-in would not clear out a tokenized credit card after 3D Secure authentication fails (#694)
 
 1.28.0
 ------

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -893,9 +893,16 @@ Dropin.prototype.requestPaymentMethod = function (options) {
 
         return payload;
       }).catch(function (err) {
-        self._mainView.hideLoadingIndicator();
+        self.clearSelectedPaymentMethod();
 
-        return Promise.reject(err);
+        return self._model.refreshPaymentMethods().then(function () {
+          self._mainView.hideLoadingIndicator();
+
+          return Promise.reject(new DropinError({
+            message: 'Something went wrong during 3D Secure authentication. Please try again.',
+            braintreeWebError: err
+          }));
+        });
       });
     }
 


### PR DESCRIPTION
closes #694

### Summary

Basically, when card tokenization happens, we add the nonce payload to the Drop-in as requestable payment method. When 3ds succeeds, we update that payload with the new nonce and liability shift info. When it fails, we don't update the data, but the nonce is still left behind as a requestable payment method, even though it has been consumed.

This PR brings the behavior up to date with the iOS and Android SDKs where if the 3ds auth fails, it clears out the consumed credit card and refreshes any vaulted payment methods.

In the future, I think it would be wise to add a feature to allow the failed 3ds auth to redirect back to the card form (if the initiating payment method was from the card form), but that will require a little more design work and a few more weeks for localization on a new error message.

This current implementation will get merchants unstuck right now.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 