### PR TITLE
Apple pay fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 unreleased
 ----------
 - Update braintree-web to v3.78.1
+- Fix issue where Apple Pay button would not disable when session begins
 
 1.30.0
 ------

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -160,20 +160,20 @@ describe('ApplePayView', () => {
     });
 
     describe('button click handler', () => {
+      let button;
+
       beforeEach(() => {
         testContext.view = new ApplePayView(testContext.applePayViewOptions);
 
         return testContext.view.initialize().then(() => {
-          const button = document.querySelector('[data-braintree-id="apple-pay-button"]');
-
-          testContext.buttonClickHandler = button.onclick;
+          button = document.querySelector('[data-braintree-id="apple-pay-button"]');
         });
       });
 
       test('creates an ApplePaySession with the payment request', () => {
         testContext.view.applePayInstance.createPaymentRequest = jest.fn().mockReturnValue(testContext.fakePaymentRequest);
 
-        testContext.buttonClickHandler();
+        button.onclick();
 
         expect(testContext.view.applePayInstance.createPaymentRequest).toBeCalledWith(testContext.fakePaymentRequest);
         expect(global.ApplePaySession).toBeCalledWith(2, testContext.fakePaymentRequest);
@@ -183,7 +183,7 @@ describe('ApplePayView', () => {
         testContext.view.applePaySessionVersion = 3;
         testContext.view.applePayInstance.createPaymentRequest = jest.fn().mockReturnValue(testContext.fakePaymentRequest);
 
-        testContext.buttonClickHandler();
+        button.onclick();
 
         expect(testContext.view.applePayInstance.createPaymentRequest).toBeCalledWith(testContext.fakePaymentRequest);
         expect(global.ApplePaySession).toBeCalledWith(3, testContext.fakePaymentRequest);
@@ -192,7 +192,7 @@ describe('ApplePayView', () => {
       test('begins the ApplePaySession', () => {
         testContext.view.applePayInstance.createPaymentRequest = jest.fn().mockReturnValue(testContext.fakePaymentRequest);
 
-        testContext.buttonClickHandler();
+        button.onclick();
 
         expect(testContext.fakeApplePaySession.begin).toBeCalledTimes(1);
       });
@@ -201,7 +201,7 @@ describe('ApplePayView', () => {
         test('performs merchant validation', () => {
           const stubEvent = { validationURL: 'fake' };
 
-          testContext.buttonClickHandler();
+          button.onclick();
           testContext.fakeApplePaySession.onvalidatemerchant(stubEvent);
 
           expect(testContext.view.applePayInstance.performValidation).toBeCalledWith({
@@ -221,7 +221,7 @@ describe('ApplePayView', () => {
               done();
             };
 
-            testContext.buttonClickHandler();
+            button.onclick();
             testContext.fakeApplePaySession.onvalidatemerchant({ validationURL: 'fake' });
           }
         );
@@ -238,7 +238,7 @@ describe('ApplePayView', () => {
               done();
             };
 
-            testContext.buttonClickHandler();
+            button.onclick();
             testContext.fakeApplePaySession.onvalidatemerchant({ validationURL: 'fake' });
           }
         );
@@ -250,7 +250,7 @@ describe('ApplePayView', () => {
             payment: { token: 'foo' }
           };
 
-          testContext.buttonClickHandler();
+          button.onclick();
           testContext.fakeApplePaySession.onpaymentauthorized(stubEvent);
 
           expect(testContext.fakeApplePayInstance.tokenize).toBeCalledWith({ token: 'foo' });
@@ -269,7 +269,7 @@ describe('ApplePayView', () => {
                 }, 200);
               };
 
-              testContext.buttonClickHandler();
+              button.onclick();
               testContext.fakeApplePaySession.onpaymentauthorized({
                 payment: { token: 'foo' }
               });
@@ -289,7 +289,7 @@ describe('ApplePayView', () => {
               done();
             };
 
-            testContext.buttonClickHandler();
+            button.onclick();
             testContext.fakeApplePaySession.onpaymentauthorized({
               payment: { token: 'foo' }
             });
@@ -311,7 +311,7 @@ describe('ApplePayView', () => {
                 done();
               };
 
-              testContext.buttonClickHandler();
+              button.onclick();
               testContext.fakeApplePaySession.onpaymentauthorized({
                 payment: {
                   token: 'foo',
@@ -338,7 +338,7 @@ describe('ApplePayView', () => {
                 done();
               };
 
-              testContext.buttonClickHandler();
+              button.onclick();
               testContext.fakeApplePaySession.onpaymentauthorized({
                 payment: { token: 'foo' }
               });

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -403,7 +403,7 @@ describe('ApplePayView', () => {
           );
 
           test(
-            'can start a new session',
+            'can start a new session after a tokenization error',
             async () => {
               const fakeError = new Error('fail.');
 


### PR DESCRIPTION
### Summary

Prevents users from double clicking Apple Pay button (causing an invalid session message in the console).

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 
