### PR TITLE
Add button role to payment option buttons for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+- Update roles on payment option buttons so that screen readers can read them as buttons
+
 1.30.1
 ------
 - Update braintree-web to v3.78.2

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -247,7 +247,7 @@
     <div data-braintree-id="other-ways-to-pay" class="braintree-heading">{{otherWaysToPay}}</div>
   </div>
 
-  <div data-braintree-id="toggle" class="braintree-large-button braintree-toggle braintree-hidden" tabindex="0">
+  <div data-braintree-id="toggle" class="braintree-large-button braintree-toggle braintree-hidden" tabindex="0" role="button">
     <span>{{chooseAnotherWayToPay}}</span>
   </div>
 </div>

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -39,7 +39,7 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
 
   div.className = 'braintree-option braintree-option__' + paymentOptionID;
   div.setAttribute('tabindex', '0');
-  div.setAttribute('role', 'button')
+  div.setAttribute('role', 'button');
 
   switch (paymentOptionID) {
     case paymentOptionIDs.applePay:

--- a/src/views/payment-options-view.js
+++ b/src/views/payment-options-view.js
@@ -39,6 +39,7 @@ PaymentOptionsView.prototype._addPaymentOption = function (paymentOptionID) {
 
   div.className = 'braintree-option braintree-option__' + paymentOptionID;
   div.setAttribute('tabindex', '0');
+  div.setAttribute('role', 'button')
 
   switch (paymentOptionID) {
     case paymentOptionIDs.applePay:


### PR DESCRIPTION
### Summary

Adds the button role the payment option buttons so that screen readers can tell that they are buttons that can be clicked.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
