### PR TITLE
fix: add oncancel handler for Apple Pay payment sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 CHANGELOG
 =========
 
-1.31.0
+unreleased
 ----------
+- Fix issue where Apple Pay would stop working after a cancellation
+
+1.31.0
+------
 - Update roles on payment option buttons so that screen readers can read them as buttons
 - Update braintree-web to v3.79.1
   - Fix issue where card form could not tab forward in iOS Safari 14.5+ (tabbing backward is still broken)

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -84,6 +84,10 @@ ApplePayView.prototype._showPaymentSheet = function () {
     });
   };
 
+  session.oncancel = function () {
+    self._sessionInProgress = false;
+  };
+
   session.begin();
 
   return false;

--- a/test/unit/views/payment-sheet-views/apple-pay-view.js
+++ b/test/unit/views/payment-sheet-views/apple-pay-view.js
@@ -426,6 +426,26 @@ describe('ApplePayView', () => {
           );
         });
       });
+
+      describe('session.oncancel', () => {
+        test('can start a new session after cancel', () => {
+          expect(testContext.fakeApplePayInstance.createPaymentRequest).toBeCalledTimes(0);
+
+          button.onclick();
+
+          expect(testContext.fakeApplePayInstance.createPaymentRequest).toBeCalledTimes(1);
+
+          button.onclick();
+
+          expect(testContext.fakeApplePayInstance.createPaymentRequest).toBeCalledTimes(1);
+
+          testContext.fakeApplePaySession.oncancel();
+
+          button.onclick();
+
+          expect(testContext.fakeApplePayInstance.createPaymentRequest).toBeCalledTimes(2);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### Summary

Currently, if a customer cancels the Apple Pay flow, it puts the button in an unreachable state. This fix handles that scenario.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
