### PR TITLE
fix: correct value for max-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+unreleased
+----------
+- Fix issue where a methods container for a cusotmer with 15+ payment methods would obscure the "Choose Another Way to Pay" button
+
 1.31.1
 ------
 - Fix issue where Apple Pay would stop working after a cancellation

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -998,7 +998,7 @@
 .braintree-loaded [data-braintree-id='methods'],
 .braintree-loaded [data-braintree-id='options'],
 .braintree-loaded [data-braintree-id='sheet-container'] {
-  max-height: 1000px; // Must set specific value here in order to have animation
+  max-height: fit-content; // Must set value here in order to have animation
   opacity: 1;
   transition: max-height 250ms @curve-easeOutBack, opacity 300ms linear 100ms;
   min-height: 0;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -998,6 +998,8 @@
 .braintree-loaded [data-braintree-id='methods'],
 .braintree-loaded [data-braintree-id='options'],
 .braintree-loaded [data-braintree-id='sheet-container'] {
+  // NEXT_MAJOR_VERSION drop this when IE support is no longer required
+  max-height: 2000px; // IE11 doesn't support fit-content, so we need a backup value here
   max-height: fit-content; // Must set value here in order to have animation
   opacity: 1;
   transition: max-height 250ms @curve-easeOutBack, opacity 300ms linear 100ms;


### PR DESCRIPTION
### Summary

Fixes issue where a customer with 15+ payment methods would cause the methods container to overflow over the "choose another way to pay" button.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 
