### PR TITLE
fix: send requestable event when card view is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ unreleased
 ----------
 - Fix issue where a methods container for a cusotmer with 15+ payment methods would obscure the "Choose Another Way to Pay" button
 - Fix issue where Drop-in could get in an unusable state when `clearSelectedPaymentMethod` was called directly after `requestPaymentMethod`
+- Fix issue where an already filled out card form would not trigger `paymentMethodRequestable` event (#761)
 - Update braintree-web to v3.80.0
 
 1.31.1

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -553,6 +553,8 @@ CardView.prototype.onSelection = function () {
       this.hostedFieldsInstance.focus('number');
     }
   }.bind(this), 50);
+
+  this._sendRequestableEvent();
 };
 
 CardView.prototype._hideUnsupportedCardIcons = function () {

--- a/test/helpers/fake.js
+++ b/test/helpers/fake.js
@@ -60,6 +60,7 @@ fakeBTInstances = {
   hostedFields() {
     return {
       clear: jest.fn(),
+      focus: jest.fn(),
       getState: jest.fn().mockReturnValue({
         cards: [{ type: 'visa' }],
         fields: {


### PR DESCRIPTION
### Summary
closes #761

Currently, if a card has been tokenized and you have Drop-in configured to not clear out the fields after tokenization, then you call `clearSelectedPaymentMethod`, the saved card is cleared, but entering the card form with an already valid card does not trigger `paymentMethodRequestable` when it should.

This is because the `paymentMethodRequestable` and `noPaymentMethodRequestable` event only fires when the hosted fields event listeners fire for validity change.

To fix this, we've set it to fire off those events when the card view is presented, for this case where the card form is already filled out.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
- @jplukarski 
