### PR TITLE
fix: stop passing card true to CardView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+1.32.1
+----------
+- Fix issue where passing `true` to card as Merchant Configuration stops creation
 
 1.32.0
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 CHANGELOG
 =========
-1.32.1
+UNRELEASED
 ----------
 - Fix issue where passing `true` to card as Merchant Configuration stops creation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-web-drop-in",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "main": "src/index.js",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-web-drop-in",
-  "version": "1.32.1",
+  "version": "1.32.0",
   "main": "src/index.js",
   "private": true,
   "scripts": {

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -180,6 +180,10 @@ DropinModel.prototype._shouldIncludeDependency = function (key) {
     if (this.merchantConfiguration.card === false) {
       return false;
     }
+    // If merchant explicty passes a value of `true`, do not pass through the value
+    if (this.merchantConfiguration.card === true) {
+      delete this.merchantConfiguration.card;
+    }
   } else if (!this.merchantConfiguration[key]) {
     // if the merchant does not have the non-card dependency
     // configured, do not include the dependency


### PR DESCRIPTION
### Summary

Fixes #775

If the merchant explicitly pass through card as true in merchant configuration options then we can ignore the property as card is turned on by default.

Attempting to fix this in the card view is more challenging as the `true` value will cause TypeErrors

### Checklist

- [ ✔] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

@the133448
