### PR TITLE
Fix incorrect nesting of Apple Pay PaymentRequest Properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -356,8 +356,10 @@ var VERSION = '__VERSION__';
  *   applePay: {
  *     displayName: 'Merchant Name',
  *     paymentRequest: {
-   *     label: 'Localized Name',
- *       total: '10.00'
+ *       total: {
+ *         label: 'Localized Name',
+ *         amount: '10.00'
+ *       }
  *     }
  *   },
  *   paypal: {


### PR DESCRIPTION
### Summary

According to the [Apple Pay Docs](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916119-total), we are not nesting our Apple Pay `paymentRequest` properties correctly [in our example](http://localhost:4567/docs/current/module-braintree-web-drop-in.html#create-examples). This PR also aligns the Drop-In Client docs with our [Developer Documentation](https://developer.paypal.com/braintree/docs/guides/drop-in/setup-and-integration#apple-pay)

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
