### PR TITLE
Fix hiper icon visibility that spoils card icons

### DIFF
--- a/src/html/card-icons.html
+++ b/src/html/card-icons.html
@@ -30,7 +30,7 @@ The  braintree-hidden class should be removed here once we get icons for these c
         <use xlink:href="#icon-elo"></use>
     </svg>
 </div>
-<div data-braintree-id="hiper-card-icon" class="braintree-sheet__card-ico braintree-hidden">
+<div data-braintree-id="hiper-card-icon" class="braintree-sheet__card-icon braintree-hidden">
     <svg width="40" height="24">
         <use xlink:href="#icon-hiper"></use>
     </svg>


### PR DESCRIPTION
### Summary

Since https://github.com/braintree/braintree-web-drop-in/pull/788 list of cards is spoiled because the hiper icon is not really hidden. Just check images before and after this fix:

Before fix:
<img width="586" alt="1 33 0" src="https://user-images.githubusercontent.com/265510/161962330-cfc5a414-c950-4cd8-b144-465e3d09d34d.png">

After fix:
<img width="586" alt="1 33 0-fixed" src="https://user-images.githubusercontent.com/265510/161962350-62f25f04-d109-4fca-ac3b-5fc31aa7cca1.png">

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.