### PR TITLE
chore: update braintree-web to 3.85.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## UNRELEASED
+  - Update braintree-web to v3.85.5
   - Fix test app accessibility errors
 
 ## 1.33.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -5136,6 +5136,25 @@
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      },
+      "dependencies": {
+        "file-uri-to-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5225,12 +5244,12 @@
       }
     },
     "braintree-web": {
-      "version": "3.85.3",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.85.3.tgz",
-      "integrity": "sha512-slCnjD/YLFDmiOU0vxL7i4uifjRQV5Cw7dSkhRdXiIT+a8iQ7NxtL5FSomv45wuHqgdilZeQ8iB8guIrn6QgwA==",
+      "version": "3.85.5",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.85.5.tgz",
+      "integrity": "sha512-fRUwF8as9SJd2PCwmdkwE94nvItGmKHmB1Py4C4RM5G/j1v6rxh67l0pXBW14RtvEbnuQ0eIMeR1JQbu/Y5K2g==",
       "requires": {
         "@braintree/asset-loader": "0.4.4",
-        "@braintree/browser-detection": "1.12.1",
+        "@braintree/browser-detection": "1.14.0",
         "@braintree/class-list": "0.2.0",
         "@braintree/event-emitter": "0.4.1",
         "@braintree/extended-promise": "0.4.1",
@@ -5244,6 +5263,13 @@
         "inject-stylesheet": "5.0.0",
         "promise-polyfill": "8.2.3",
         "restricted-input": "3.0.5"
+      },
+      "dependencies": {
+        "@braintree/browser-detection": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.14.0.tgz",
+          "integrity": "sha512-OsqU+28RhNvSw8Y5JEiUHUrAyn4OpYazFkjSJe8ZVZfkAaRXQc6hsV38MMEpIlkPMig+A68buk/diY+0O8/dMQ=="
+        }
       }
     },
     "brfs": {
@@ -9301,6 +9327,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5263,13 +5263,6 @@
         "inject-stylesheet": "5.0.0",
         "promise-polyfill": "8.2.3",
         "restricted-input": "3.0.5"
-      },
-      "dependencies": {
-        "@braintree/browser-detection": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.14.0.tgz",
-          "integrity": "sha512-OsqU+28RhNvSw8Y5JEiUHUrAyn4OpYazFkjSJe8ZVZfkAaRXQc6hsV38MMEpIlkPMig+A68buk/diY+0O8/dMQ=="
-        }
       }
     },
     "brfs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -452,9 +452,9 @@
       }
     },
     "@braintree/browser-detection": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.12.1.tgz",
-      "integrity": "sha512-i/54qrax5o/WbJJhsE/7qqKE594/kGhR+xSu/w13rT7Mlr/uITkWDXzxffcKQ6l6FQxK0IG0EfgT6TJpWgZcUQ=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.14.0.tgz",
+      "integrity": "sha512-OsqU+28RhNvSw8Y5JEiUHUrAyn4OpYazFkjSJe8ZVZfkAaRXQc6hsV38MMEpIlkPMig+A68buk/diY+0O8/dMQ=="
     },
     "@braintree/class-list": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@braintree/asset-loader": "0.4.4",
-    "@braintree/browser-detection": "^1.14.0",
+    "@braintree/browser-detection": "1.14.0",
     "@braintree/class-list": "0.2.0",
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.85.3",
+    "braintree-web": "3.85.5",
     "promise-polyfill": "8.2.3"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@braintree/asset-loader": "0.4.4",
-    "@braintree/browser-detection": "1.12.1",
+    "@braintree/browser-detection": "^1.14.0",
     "@braintree/class-list": "0.2.0",
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",


### PR DESCRIPTION
### Summary

<!-- NOTE: We cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. 

If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team. 

You may provide your own custom translations by using the `translations` paramter when creating the Drop-in instance: https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create
-->

Updating to the latest `braintree-web` version of `v3.85.5`.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
