### PR TITLE
update braintree-web to v3.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+  - Update braintree-web to v3.86.0
+  
 ## 1.33.3
   - Update braintree-web to v3.85.5
   - Fix test app accessibility errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -5244,9 +5244,9 @@
       }
     },
     "braintree-web": {
-      "version": "3.85.5",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.85.5.tgz",
-      "integrity": "sha512-fRUwF8as9SJd2PCwmdkwE94nvItGmKHmB1Py4C4RM5G/j1v6rxh67l0pXBW14RtvEbnuQ0eIMeR1JQbu/Y5K2g==",
+      "version": "3.86.0",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.86.0.tgz",
+      "integrity": "sha512-Z7t6Sq06cpiwCIwuREyprla/pKxRlVs6Cw4AV8ORn0dyxao6U2rt8IobYkwuQmrc0MzdjJ5BLOu/cn5PMZhz+A==",
       "requires": {
         "@braintree/asset-loader": "0.4.4",
         "@braintree/browser-detection": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.85.5",
+    "braintree-web": "3.86.0",
     "promise-polyfill": "8.2.3"
   },
   "browserify": {


### PR DESCRIPTION
### Summary

Get the latest from Braintree-web for Dropin.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
