### PR TITLE
fix: update check for PayPal Credit presence

### DIFF
--- a/test/integration/request-payment-method.test.js
+++ b/test/integration/request-payment-method.test.js
@@ -59,7 +59,7 @@ describe('Drop-in#requestPaymentMethod', function () {
 
       browser.clickOption('paypalCredit');
       browser.openPayPalAndCompleteLogin(function () {
-        expect($('.fsPanel.CREDIT').isExisting()).toBe(true);
+        expect($('img[alt="PayPal Credit"]').isExisting()).toBe(true);
       });
 
       browser.submitPay();


### PR DESCRIPTION
### Summary

Looks like something changed in the log-in flow for PayPal, and the check for the presence of the PayPal Credit option is now different. This updates the check to target the image with alt text "PayPal Credit", which will hopefully be more stable.

### Checklist

- [ ] ~~Added a changelog entry~~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
