### PR TITLE
chore: drop promise-polyfill

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,5 +16,6 @@
         key-spacing: 0
 
   globals:
-    __dirname: true
-    process: true
+    __dirname: "readonly"
+    process: "readonly"
+    Promise: "readonly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+  - Drop dependency on `promise-polyfill`
+
 ## 1.36.1
   - Update braintree-web to 3.92.1
 

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.92.1",
-    "promise-polyfill": "8.2.3"
+    "braintree-web": "3.92.1"
   },
   "browserify": {
     "transform": [

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -8,7 +8,6 @@ var paymentMethodTypes = constants.paymentMethodTypes;
 var paymentOptionIDs = constants.paymentOptionIDs;
 var dependencySetupStates = constants.dependencySetupStates;
 var isGuestCheckout = require('./lib/is-guest-checkout');
-var Promise = require('./lib/promise');
 var paymentSheetViews = require('./views/payment-sheet-views');
 var vaultManager = require('braintree-web/vault-manager');
 var paymentOptionsViewID = require('./views/payment-options-view').ID;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -15,7 +15,6 @@ var paymentOptionIDs = constants.paymentOptionIDs;
 var translations = require('./translations').translations;
 var isUtf8 = require('./lib/is-utf-8');
 var uuid = require('@braintree/uuid');
-var Promise = require('./lib/promise');
 var sanitizeHtml = require('./lib/sanitize-html');
 var DataCollector = require('./lib/data-collector');
 var ThreeDSecure = require('./lib/three-d-secure');

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,6 @@ var createFromScriptTag = require('./lib/create-from-script-tag');
 var constants = require('./constants');
 var analytics = require('./lib/analytics');
 var DropinError = require('./lib/dropin-error');
-var Promise = require('./lib/promise');
 var wrapPromise = require('@braintree/wrap-promise');
 
 var VERSION = '__VERSION__';

--- a/src/lib/data-collector.js
+++ b/src/lib/data-collector.js
@@ -3,7 +3,6 @@
 var constants = require('../constants');
 var analytics = require('./analytics');
 var assets = require('@braintree/asset-loader');
-var Promise = require('./promise');
 
 function DataCollector(config) {
   this._config = config;

--- a/src/lib/wait.js
+++ b/src/lib/wait.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('./promise');
-
 function delay(time) {
   time = time || 0;
 

--- a/src/views/base-view.js
+++ b/src/views/base-view.js
@@ -4,7 +4,6 @@ var assign = require('../lib/assign').assign;
 var classList = require('@braintree/class-list');
 var DropinError = require('../lib/dropin-error');
 var errors = require('../constants').errors;
-var Promise = require('../lib/promise');
 
 function BaseView(options) {
   options = options || {};

--- a/src/views/main-view.js
+++ b/src/views/main-view.js
@@ -9,7 +9,6 @@ var PaymentMethodsView = require('./payment-methods-view');
 var PaymentOptionsView = require('./payment-options-view');
 var DeleteConfirmationView = require('./delete-confirmation-view');
 var addSelectionEventHandler = require('../lib/add-selection-event-handler');
-var Promise = require('../lib/promise');
 var wait = require('../lib/wait');
 var supportsFlexbox = require('../lib/supports-flexbox');
 

--- a/src/views/payment-methods-view.js
+++ b/src/views/payment-methods-view.js
@@ -5,7 +5,6 @@ var PaymentMethodView = require('./payment-method-view');
 var DropinError = require('../lib/dropin-error');
 var classList = require('@braintree/class-list');
 var errors = require('../constants').errors;
-var Promise = require('../lib/promise');
 var addSelectionEventHandler = require('../lib/add-selection-event-handler');
 
 var PAYMENT_METHOD_TYPE_TO_TRANSLATION_STRING = {

--- a/src/views/payment-sheet-views/apple-pay-view.js
+++ b/src/views/payment-sheet-views/apple-pay-view.js
@@ -5,7 +5,6 @@ var BaseView = require('../base-view');
 var btApplePay = require('braintree-web/apple-pay');
 var DropinError = require('../../lib/dropin-error');
 var isHTTPS = require('../../lib/is-https');
-var Promise = require('../../lib/promise');
 var paymentOptionIDs = require('../../constants').paymentOptionIDs;
 
 var DEFAULT_APPLE_PAY_SESSION_VERSION = 2;

--- a/src/views/payment-sheet-views/base-paypal-view.js
+++ b/src/views/payment-sheet-views/base-paypal-view.js
@@ -9,7 +9,6 @@ var DropinError = require('../../lib/dropin-error');
 var constants = require('../../constants');
 var assets = require('@braintree/asset-loader');
 var translations = require('../../translations').fiveCharacterLocales;
-var Promise = require('../../lib/promise');
 
 var ASYNC_DEPENDENCY_TIMEOUT = 30000;
 var READ_ONLY_CONFIGURATION_OPTIONS = ['offerCredit', 'locale'];

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -9,7 +9,6 @@ var DropinError = require('../../lib/dropin-error');
 var hostedFields = require('braintree-web/hosted-fields');
 var isUtf8 = require('../../lib/is-utf-8');
 var transitionHelper = require('../../lib/transition-helper');
-var Promise = require('../../lib/promise');
 
 var cardIconHTML = fs.readFileSync(__dirname + '/../../html/card-icons.html', 'utf8');
 

--- a/src/views/payment-sheet-views/google-pay-view.js
+++ b/src/views/payment-sheet-views/google-pay-view.js
@@ -6,7 +6,6 @@ var btGooglePay = require('braintree-web/google-payment');
 var DropinError = require('../../lib/dropin-error');
 var constants = require('../../constants');
 var assets = require('@braintree/asset-loader');
-var Promise = require('../../lib/promise');
 var analytics = require('../../lib/analytics');
 
 function GooglePayView() {

--- a/src/views/payment-sheet-views/paypal-credit-view.js
+++ b/src/views/payment-sheet-views/paypal-credit-view.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assign = require('../../lib/assign').assign;
-var Promise = require('../../lib/promise');
 var paymentOptionIDs = require('../../constants').paymentOptionIDs;
 var BasePayPalView = require('./base-paypal-view');
 

--- a/src/views/payment-sheet-views/paypal-view.js
+++ b/src/views/payment-sheet-views/paypal-view.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assign = require('../../lib/assign').assign;
-var Promise = require('../../lib/promise');
 var paymentOptionIDs = require('../../constants').paymentOptionIDs;
 var BasePayPalView = require('./base-paypal-view');
 

--- a/src/views/payment-sheet-views/venmo-view.js
+++ b/src/views/payment-sheet-views/venmo-view.js
@@ -4,7 +4,6 @@ var assign = require('../../lib/assign').assign;
 var BaseView = require('../base-view');
 var btVenmo = require('braintree-web/venmo');
 var DropinError = require('../../lib/dropin-error');
-var Promise = require('../../lib/promise');
 var paymentOptionIDs = require('../../constants').paymentOptionIDs;
 
 function VenmoView() {


### PR DESCRIPTION
### Summary

Drops usage of `promise-polyfill` since all browsers we support now support promises.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
