### PR TITLE
fix: update tests to include postal code for HF

### DIFF
--- a/test/integration/card-customization.test.js
+++ b/test/integration/card-customization.test.js
@@ -33,6 +33,7 @@ describe('Drop-in card', function () {
       browser.hostedFieldSendInput('number');
       browser.hostedFieldSendInput('expirationDate');
       browser.hostedFieldSendInput('cvv');
+      browser.hostedFieldSendInput('postalCode');
 
       expect($('#pay-button').isEnabled()).toBe(true);
 
@@ -54,6 +55,7 @@ describe('Drop-in card', function () {
       browser.hostedFieldSendInput('number');
       browser.hostedFieldSendInput('expirationDate');
       browser.hostedFieldSendInput('cvv');
+      browser.hostedFieldSendInput('postalCode');
 
       expect($('#pay-button').isEnabled()).toBe(false);
 
@@ -166,6 +168,7 @@ describe('Drop-in card', function () {
       browser.hostedFieldSendInput('number');
       browser.hostedFieldSendInput('expirationDate');
       browser.hostedFieldSendInput('cvv');
+      browser.hostedFieldSendInput('postalCode');
 
       browser.submitPay();
 
@@ -186,6 +189,7 @@ describe('Drop-in card', function () {
       browser.hostedFieldSendInput('number');
       browser.hostedFieldSendInput('expirationDate');
       browser.hostedFieldSendInput('cvv');
+      browser.hostedFieldSendInput('postalCode');
 
       browser.submitPay();
 

--- a/test/integration/clear-selected-payment-method.test.js
+++ b/test/integration/clear-selected-payment-method.test.js
@@ -9,6 +9,7 @@ describe('Drop-in#clearSelectedPaymentMethod', function () {
     browser.hostedFieldSendInput('number');
     browser.hostedFieldSendInput('expirationDate');
     browser.hostedFieldSendInput('cvv');
+    browser.hostedFieldSendInput('postalCode');
 
     browser.submitPay();
 

--- a/test/integration/data-collector.test.js
+++ b/test/integration/data-collector.test.js
@@ -13,6 +13,7 @@ describe('Drop-in with Data Collector', function () {
     browser.hostedFieldSendInput('number');
     browser.hostedFieldSendInput('expirationDate');
     browser.hostedFieldSendInput('cvv');
+    browser.hostedFieldSendInput('postalCode');
 
     browser.submitPay();
 

--- a/test/integration/events.test.js
+++ b/test/integration/events.test.js
@@ -17,6 +17,7 @@ describe('Drop-in events', function () {
     browser.hostedFieldSendInput('number');
     browser.hostedFieldSendInput('expirationDate');
     browser.hostedFieldSendInput('cvv');
+    browser.hostedFieldSendInput('postalCode');
 
     expect($('#pay-button').isEnabled()).toBe(true);
 

--- a/test/integration/request-payment-method.test.js
+++ b/test/integration/request-payment-method.test.js
@@ -10,6 +10,7 @@ describe('Drop-in#requestPaymentMethod', function () {
       browser.hostedFieldSendInput('number');
       browser.hostedFieldSendInput('expirationDate');
       browser.hostedFieldSendInput('cvv');
+      browser.hostedFieldSendInput('postalCode');
 
       browser.submitPay();
 
@@ -83,6 +84,7 @@ describe('Drop-in#requestPaymentMethod', function () {
       browser.hostedFieldSendInput('number');
       browser.hostedFieldSendInput('expirationDate');
       browser.hostedFieldSendInput('cvv');
+      browser.hostedFieldSendInput('postalCode');
 
       browser.submitPay();
 

--- a/test/integration/script-tag-integration.test.js
+++ b/test/integration/script-tag-integration.test.js
@@ -19,6 +19,7 @@ describe('Drop-in Script Tag Integration', function () {
     browser.hostedFieldSendInput('number');
     browser.hostedFieldSendInput('expirationDate');
     browser.hostedFieldSendInput('cvv');
+    browser.hostedFieldSendInput('postalCode');
 
     browser.submitPay(false);
 


### PR DESCRIPTION
### Summary

The Sandbox merchant used in the tests had the postal code validations turned on, which means that Drop-in in the demo app now has the postal code field as a required input.

This PR adds that to the test harness.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @crookedneighbor 
