### PR TITLE
Fix: Removing card icons if they are overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
-  - No longer showing card icons for overridden card types.
+  - Fix issue where supportedCardBrands overrides were incorrectly showing images for hidden card brands
 
 ## 1.37.0
   - Drop dependency on `promise-polyfill`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+  - No longer showing card icons for overridden card types.
+
 ## 1.37.0
   - Drop dependency on `promise-polyfill`
   - Drop dependency on @braintree/class-list

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,19 @@ module.exports = {
     Hiper: 'hiper',
     Hipercard: 'hipercard'
   },
+  cardTypeIcons: {
+    visa: 'visa',
+    mastercard: 'master-card',
+    'american-express': 'american-express',
+    'diners-club': 'diners-club',
+    discover: 'discover',
+    jcb: 'jcb',
+    'union-pay': 'unionpay',
+    maestro: 'maestro',
+    elo: 'elo',
+    hiper: 'hiper',
+    hipercard: 'hipercard'
+  },
   configurationCardTypes: {
     visa: 'Visa',
     'master-card': 'MasterCard',

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -116,27 +116,21 @@ CardView.prototype._sendRequestableEvent = function () {
 CardView.prototype._renderCardIcons = function () {
   var overrides = this.merchantConfiguration.overrides;
   var cardIcons = this.getElementById('card-view-icons');
-  var supportedCardBrands;
+  var supportedCardBrands = overrides && overrides.fields && overrides.fields.number && overrides.fields.number.supportedCardBrands;
 
   cardIcons.innerHTML = cardIconHTML;
 
-  try {
-    supportedCardBrands = overrides.fields.number.supportedCardBrands;
+  if (supportedCardBrands) {
+    Object.keys(supportedCardBrands).forEach(function (cardBrand) {
+      var value = supportedCardBrands[cardBrand];
+      var selector, iconDiv;
 
-    if (supportedCardBrands) {
-      Object.keys(supportedCardBrands).forEach(function (cardBrand) {
-        var value = supportedCardBrands[cardBrand];
-        var selector, iconDiv;
-
-        if (value === false) {
-          selector = 'div[data-braintree-id="' + constants.cardTypeIcons[cardBrand] + '-card-icon"]';
-          iconDiv = document.querySelector(selector);
-          hideCardIcon(iconDiv);
-        }
-      });
-    }
-  } catch (error) {
-    return;
+      if (value === false) {
+        selector = 'div[data-braintree-id="' + constants.cardTypeIcons[cardBrand] + '-card-icon"]';
+        iconDiv = document.querySelector(selector);
+        hideCardIcon(iconDiv);
+      }
+    });
   }
 };
 

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -116,16 +116,16 @@ CardView.prototype._sendRequestableEvent = function () {
 CardView.prototype._renderCardIcons = function () {
   var overrides = this.merchantConfiguration.overrides;
   var cardIcons = this.getElementById('card-view-icons');
-  var supportCardBrands;
+  var supportedCardBrands;
 
   cardIcons.innerHTML = cardIconHTML;
 
   try {
-    supportCardBrands = overrides.fields.number.supportedCardBrands;
+    supportedCardBrands = overrides.fields.number.supportedCardBrands;
 
-    if (supportCardBrands) {
-      Object.keys(supportCardBrands).forEach(function (cardBrand) {
-        var value = supportCardBrands[cardBrand];
+    if (supportedCardBrands) {
+      Object.keys(supportedCardBrands).forEach(function (cardBrand) {
+        var value = supportedCardBrands[cardBrand];
         var selector, iconDiv;
 
         if (value === false) {

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -571,6 +571,54 @@ describe('CardView', () => {
       });
     });
 
+    test('does not error if overridden icons is empty', () => {
+      fakeModel.merchantConfiguration.card = {
+        overrides: {}
+      };
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      jest.spyOn(view, '_renderCardIcons');
+
+      return view.initialize().then(() => {
+        expect(view._renderCardIcons).toBeCalledTimes(1);
+        expect(view._renderCardIcons).toReturn();
+      });
+    });
+
+    test('does not error if merchant passes in an unknown card vendor to card overrides', () => {
+      fakeModel.merchantConfiguration.card = {
+        overrides: {
+          fields: {
+            number: {
+              supportedCardBrands: {
+                'unknown-card-vendor': false
+              }
+            }
+          }
+        }
+      };
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      jest.spyOn(view, '_renderCardIcons');
+
+      return view.initialize().then(() => {
+        expect(view._renderCardIcons).toBeCalledTimes(1);
+        expect(view._renderCardIcons).toReturn();
+      });
+    });
+
     test('does not show Elo icon even if it is supported', () => {
       let eloCardIcon;
 

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -13,6 +13,7 @@ const {
 
 const mainHTML = fs.readFileSync(__dirname + '/../../../../src/html/main.html', 'utf8');
 const CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT = require('../../../../src/constants').CHANGE_ACTIVE_PAYMENT_METHOD_TIMEOUT;
+const constants = require('../../../../src/constants');
 
 describe('CardView', () => {
   let fakeClient, fakeHostedFieldsInstance, cardElement, container;
@@ -506,7 +507,10 @@ describe('CardView', () => {
         strings: strings
       });
 
+      jest.spyOn(view, '_renderCardIcons');
+
       return view.initialize().then(() => {
+        expect(view._renderCardIcons).toBeCalledTimes(1);
         supportedCardTypes.forEach(cardType => {
           const cardIcon = cardElement.querySelector('[data-braintree-id="' + cardType + '-card-icon"]');
 
@@ -531,6 +535,39 @@ describe('CardView', () => {
 
           expect(cardIcon.classList.contains('braintree-hidden')).toBe(true);
         });
+      });
+    });
+
+    test('hides card icons if they are overriden', () => {
+      fakeModel.merchantConfiguration.card = {
+        overrides: {
+          fields: {
+            number: {
+              supportedCardBrands: {
+                'american-express': false,
+                jcb: false
+              }
+            }
+          }
+        }
+      };
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      jest.spyOn(view, '_renderCardIcons');
+
+      return view.initialize().then(() => {
+        expect(view._renderCardIcons).toBeCalledTimes(1);
+        const amexIcon = cardElement.querySelector('[data-braintree-id="' + constants.cardTypeIcons['american-express'] + '-card-icon"]');
+        const jcbIcon = cardElement.querySelector('[data-braintree-id="' + constants.cardTypeIcons.jcb + '-card-icon"]');
+
+        expect(amexIcon.classList.contains('braintree-hidden')).toBe(true);
+        expect(jcbIcon.classList.contains('braintree-hidden')).toBe(true);
       });
     });
 


### PR DESCRIPTION
### Summary

Currently, if a card type is overridden in the `card.overrides.fields.number.supportedCardBrands` object, the buyer sees an error message during card validation, but the card icon is still being shown. This change adds the `braintree-hidden` class to any card type that's being overridden by the merchant.

Ticket for internal tracking: https://paypal.atlassian.net/browse/LI-10689

![2023-05-10_12-46-21 (1)](https://github.com/braintree/braintree-web-drop-in/assets/63573634/f90412f8-fe4a-43d0-9e68-9804d34bd6d0)

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
