### PR TITLE
Fix: navigating back to initial view when calling clearSelectedPaymentMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+ - Fix issue where `clearSelectedPaymentMethod` does not navigate back to the initial view unless we are in the methods view
+
 ## 1.38.0
   - Fix issue where supportedCardBrands overrides were incorrectly showing images for hidden card brands
 

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -9,7 +9,6 @@ var EventEmitter = require('@braintree/event-emitter');
 var assets = require('@braintree/asset-loader');
 var fs = require('fs');
 var MainView = require('./views/main-view');
-var paymentMethodsViewID = require('./views/payment-methods-view').ID;
 var paymentOptionIDs = constants.paymentOptionIDs;
 var translations = require('./translations').translations;
 var isUtf8 = require('./lib/is-utf-8');
@@ -714,9 +713,10 @@ Dropin.prototype._removeUnvaultedPaymentMethods = function (filter) {
 };
 
 Dropin.prototype._navigateToInitialView = function () {
-  var isOnMethodsView = this._mainView.primaryView.ID === paymentMethodsViewID;
+  var initViewId = this._model.getInitialViewId();
+  var isOnInitView = this._mainView.primaryView.ID === initViewId;
 
-  if (!isOnMethodsView) {
+  if (isOnInitView) {
     return;
   }
 
@@ -724,7 +724,7 @@ Dropin.prototype._navigateToInitialView = function () {
     return;
   }
 
-  this._mainView.setPrimaryView(this._model.getInitialViewId());
+  this._mainView.setPrimaryView(initViewId);
 };
 
 Dropin.prototype._supportsPaymentOption = function (paymentOption) {

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1913,8 +1913,9 @@ describe('Dropin', () => {
     );
 
     test(
-      'does not set primary view if current primary view is not methods',
+      'does not set primary view if current primary view is already initial view',
       () => {
+        const initialViewID = 'options';
         const instance = new Dropin(testContext.dropinOptions);
         const getViewStub = jest.fn();
         const fakePayPalView = {
@@ -1929,7 +1930,7 @@ describe('Dropin', () => {
         instance._mainView = {
           getView: getViewStub,
           primaryView: {
-            ID: 'any-id-but-methods'
+            ID: initialViewID
           },
           setPrimaryView: jest.fn()
         };
@@ -1937,7 +1938,7 @@ describe('Dropin', () => {
           getPaymentMethods: jest.fn().mockReturnValue([]),
           removePaymentMethod: jest.fn(),
           hasPaymentMethods: jest.fn().mockReturnValue(false),
-          getInitialViewId: jest.fn().mockReturnValue('options')
+          getInitialViewId: jest.fn().mockReturnValue(initialViewID)
         };
 
         getViewStub.mockImplementation(arg => { // eslint-disable-line consistent-return
@@ -1951,6 +1952,50 @@ describe('Dropin', () => {
         instance.updateConfiguration('paypal', 'foo', 'bar');
 
         expect(instance._mainView.setPrimaryView).not.toBeCalled();
+      }
+    );
+
+    test(
+      'sets primary view if current primary view is not the initial view',
+      () => {
+        const initialViewID = 'options';
+        const instance = new Dropin(testContext.dropinOptions);
+        const getViewStub = jest.fn();
+        const fakePayPalView = {
+          updateConfiguration: jest.fn()
+        };
+        const fakeMethodsView = {
+          getPaymentMethod: jest.fn().mockReturnValue({
+            type: 'PayPalAccount'
+          })
+        };
+
+        instance._mainView = {
+          getView: getViewStub,
+          primaryView: {
+            ID: 'any-id-but-options'
+          },
+          setPrimaryView: jest.fn()
+        };
+        instance._model = {
+          getPaymentMethods: jest.fn().mockReturnValue([]),
+          removePaymentMethod: jest.fn(),
+          hasPaymentMethods: jest.fn().mockReturnValue(false),
+          getInitialViewId: jest.fn().mockReturnValue(initialViewID)
+        };
+
+        getViewStub.mockImplementation(arg => { // eslint-disable-line consistent-return
+          if (arg === 'paypal') {
+            return fakePayPalView;
+          } else if (arg === 'methods') {
+            return fakeMethodsView;
+          }
+        });
+
+        instance.updateConfiguration('paypal', 'foo', 'bar');
+
+        expect(instance._mainView.setPrimaryView).toBeCalledTimes(1);
+        expect(instance._mainView.setPrimaryView).toBeCalledWith(initialViewID);
       }
     );
 
@@ -2149,8 +2194,9 @@ describe('Dropin', () => {
     );
 
     test(
-      'does not set primary view if current primary view is not methods',
+      'does not set primary view if current primary view is already initial view',
       () => {
+        const initialViewID = 'paypal';
         const instance = new Dropin(testContext.dropinOptions);
         const getViewStub = jest.fn();
         const fakeMethodsView = {
@@ -2164,7 +2210,7 @@ describe('Dropin', () => {
           showLoadingIndicator: jest.fn(),
           hideLoadingIndicator: jest.fn(),
           primaryView: {
-            ID: 'any-id-but-methods'
+            ID: initialViewID
           },
           setPrimaryView: jest.fn()
         };
@@ -2174,7 +2220,7 @@ describe('Dropin', () => {
           removeActivePaymentMethod: jest.fn(),
           removePaymentMethod: jest.fn(),
           hasPaymentMethods: jest.fn().mockReturnValue(false),
-          getInitialViewId: jest.fn().mockReturnValue('paypal')
+          getInitialViewId: jest.fn().mockReturnValue(initialViewID)
         };
 
         getViewStub.mockImplementation(arg => { // eslint-disable-line consistent-return
@@ -2186,6 +2232,81 @@ describe('Dropin', () => {
         instance.clearSelectedPaymentMethod();
 
         expect(instance._mainView.setPrimaryView).not.toBeCalled();
+      }
+    );
+
+    test(
+      'sets primary view if current primary view is not the initial view',
+      () => {
+        const initialViewID = 'card';
+        const instance = new Dropin(testContext.dropinOptions);
+        const getViewStub = jest.fn();
+        const fakeMethodsView = {
+          getPaymentMethod: jest.fn().mockReturnValue({
+            type: 'PayPalAccount'
+          })
+        };
+
+        instance._mainView = {
+          getView: getViewStub,
+          showLoadingIndicator: jest.fn(),
+          hideLoadingIndicator: jest.fn(),
+          primaryView: {
+            ID: 'any-id-but-paypal'
+          },
+          setPrimaryView: jest.fn()
+        };
+        instance._model = {
+          refreshPaymentMethods: jest.fn().mockResolvedValue(),
+          getPaymentMethods: jest.fn().mockReturnValue([]),
+          removeActivePaymentMethod: jest.fn(),
+          removePaymentMethod: jest.fn(),
+          hasPaymentMethods: jest.fn().mockReturnValue(false),
+          getInitialViewId: jest.fn().mockReturnValue(initialViewID)
+        };
+
+        getViewStub.mockImplementation(arg => { // eslint-disable-line consistent-return
+          if (arg === 'methods') {
+            return fakeMethodsView;
+          }
+        });
+
+        instance.clearSelectedPaymentMethod();
+
+        expect(instance._mainView.setPrimaryView).toBeCalledTimes(1);
+        expect(instance._mainView.setPrimaryView).toBeCalledWith(initialViewID);
+      }
+    );
+
+    test(
+      'sets primary view from card view when initial view is options and there are no payment methods',
+      () => {
+        const initialViewID = 'options';
+        const instance = new Dropin(testContext.dropinOptions);
+
+        instance._mainView = {
+          getView: jest.fn(),
+          showLoadingIndicator: jest.fn(),
+          hideLoadingIndicator: jest.fn(),
+          primaryView: {
+            ID: 'card'
+          },
+          setPrimaryView: jest.fn()
+        };
+        instance._model = {
+          refreshPaymentMethods: jest.fn().mockResolvedValue(),
+          getPaymentMethods: jest.fn().mockReturnValue([]),
+          removeActivePaymentMethod: jest.fn(),
+          removePaymentMethod: jest.fn(),
+          hasPaymentMethods: jest.fn().mockReturnValue(false),
+          getInitialViewId: jest.fn().mockReturnValue(initialViewID)
+        };
+
+        instance.clearSelectedPaymentMethod();
+
+        expect(instance._model.hasPaymentMethods()).toBe(false);
+        expect(instance._mainView.setPrimaryView).toBeCalledTimes(1);
+        expect(instance._mainView.setPrimaryView).toBeCalledWith(initialViewID);
       }
     );
 


### PR DESCRIPTION
### Summary

Calling `clearSelectedPaymentMethod` should return the customer to the payment options view as described in [the docs](https://braintree.github.io/braintree-web-drop-in/docs/current/Dropin.html#clearSelectedPaymentMethod). Currently, this only happens if the customer is on the methods view.

With these changes, the buyer is always navigated back to the initial view (normally options, unless there is only one supported payment source) whenever the merchant calls `clearSelectedPaymentMethod`.

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @oscarleonnogales 
