### PR TITLE
Add aria-hidden to generic card icon and aria-required to Hosted Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+  - Accessibility improvements
+    - Add `aria-hidden` attribute to generic card icon
+    - Add `aria-required` attribute to Hosted Fields
+
 ## 1.40.2
   - Fix issue where some assets for the Drop-In would not load from the CDN
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Accessibility improvements
     - Add `aria-hidden` attribute to generic card icon
     - Add `aria-required` attribute to Hosted Fields
+  - Update browser-detection to v1.17.1
 
 ## 1.40.2
   - Fix issue where some assets for the Drop-In would not load from the CDN

--- a/package-lock.json
+++ b/package-lock.json
@@ -501,9 +501,9 @@
       }
     },
     "@braintree/browser-detection": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.14.0.tgz",
-      "integrity": "sha512-OsqU+28RhNvSw8Y5JEiUHUrAyn4OpYazFkjSJe8ZVZfkAaRXQc6hsV38MMEpIlkPMig+A68buk/diY+0O8/dMQ=="
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.17.1.tgz",
+      "integrity": "sha512-Mk7jauyp9pD14BTRS7otoy9dqIJGb3Oy0XtxKM/adGD9i9MAuCjH5uRZMyW2iVmJQTaA/PLlWdG7eSDyMWMc8Q=="
     },
     "@braintree/event-emitter": {
       "version": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2892,13 +2892,6 @@
         "inject-stylesheet": "5.0.0",
         "promise-polyfill": "8.2.3",
         "restricted-input": "3.0.5"
-      },
-      "dependencies": {
-        "@braintree/browser-detection": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.17.1.tgz",
-          "integrity": "sha512-Mk7jauyp9pD14BTRS7otoy9dqIJGb3Oy0XtxKM/adGD9i9MAuCjH5uRZMyW2iVmJQTaA/PLlWdG7eSDyMWMc8Q=="
-        }
       }
     },
     "brfs": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@braintree/asset-loader": "0.4.4",
-    "@braintree/browser-detection": "1.14.0",
+    "@braintree/browser-detection": "1.17.1",
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",
     "@braintree/wrap-promise": "2.1.0",

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -111,8 +111,8 @@
         <div data-braintree-id="card-sheet-header" class="braintree-sheet__header">
           <div class="braintree-sheet__header-label">
             <div class="braintree-sheet__logo--header">
-              <svg width="40" height="24" class="braintree-icon--bordered">
-                <use xlink:href="#iconCardFront"></use>
+              <svg width="40" height="24" class="braintree-icon--bordered" aria-hidden="true">
+                <use xlink:href="#iconCardFront" ></use>
               </svg>
             </div>
             <div class="braintree-sheet__text">{{payWithCard}}</div>

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -112,7 +112,7 @@
           <div class="braintree-sheet__header-label">
             <div class="braintree-sheet__logo--header">
               <svg width="40" height="24" class="braintree-icon--bordered" aria-hidden="true">
-                <use xlink:href="#iconCardFront" ></use>
+                <use xlink:href="#iconCardFront"></use>
               </svg>
             </div>
             <div class="braintree-sheet__text">{{payWithCard}}</div>

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -88,6 +88,11 @@ CardView.prototype.initialize = function () {
     this.hostedFieldsInstance.on('focus', this._onFocusEvent.bind(this));
     this.hostedFieldsInstance.on('notEmpty', this._onNotEmptyEvent.bind(this));
     this.hostedFieldsInstance.on('validityChange', this._onValidityChangeEvent.bind(this));
+    ['number', 'expirationDate', 'cvv', 'postalCode', 'cardholderName'].forEach(function (hostedField) {
+      this.hostedFieldsInstance.setAttribute({
+        field: hostedField, attribute: 'aria-required', value: true
+      });
+    }.bind(this));
 
     PASSTHROUGH_EVENTS.forEach(function (eventName) {
       this.hostedFieldsInstance.on(eventName, function (event) {

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -18,6 +18,14 @@ var PASSTHROUGH_EVENTS = [
   'binAvailable'
 ];
 
+var HOSTED_FIELDS = [
+  'number',
+  'expirationDate',
+  'cvv',
+  'postalCode',
+  'cardholderName'
+];
+
 function CardView() {
   BaseView.apply(this, arguments);
 }
@@ -57,16 +65,25 @@ CardView.prototype.initialize = function () {
 
   if (!this.hasCardholderName) {
     cardholderNameGroup.parentNode.removeChild(cardholderNameGroup);
+    HOSTED_FIELDS = HOSTED_FIELDS.filter(function (field) {
+      return field !== 'cardholderName';
+    });
   }
 
   if (!this.hasCVV) {
     cvvFieldGroup = this.getElementById('cvv-field-group');
     cvvFieldGroup.parentNode.removeChild(cvvFieldGroup);
+    HOSTED_FIELDS = HOSTED_FIELDS.filter(function (field) {
+      return field !== 'cvv';
+    });
   }
 
   if (!hfOptions.fields.postalCode) {
     postalCodeFieldGroup = this.getElementById('postal-code-field-group');
     postalCodeFieldGroup.parentNode.removeChild(postalCodeFieldGroup);
+    HOSTED_FIELDS = HOSTED_FIELDS.filter(function (field) {
+      return field !== 'postalCode';
+    });
   }
 
   if (!this.model.isGuestCheckout && this.merchantConfiguration.vault.allowVaultCardOverride === true) {
@@ -88,7 +105,7 @@ CardView.prototype.initialize = function () {
     this.hostedFieldsInstance.on('focus', this._onFocusEvent.bind(this));
     this.hostedFieldsInstance.on('notEmpty', this._onNotEmptyEvent.bind(this));
     this.hostedFieldsInstance.on('validityChange', this._onValidityChangeEvent.bind(this));
-    ['number', 'expirationDate', 'cvv', 'postalCode', 'cardholderName'].forEach(function (hostedField) {
+    HOSTED_FIELDS.forEach(function (hostedField) {
       this.hostedFieldsInstance.setAttribute({
         field: hostedField, attribute: 'aria-required', value: true
       });

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -726,7 +726,7 @@ describe('CardView', () => {
       });
     });
 
-    test.only('sets aria-required attribute on hosted fields', () => {
+    test('sets aria-required attribute on hosted fields', () => {
       fakeClient.getConfiguration.mockReturnValue({
         gatewayConfiguration: {
           challenges: ['cvv', 'postal_code'],

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -718,6 +718,7 @@ describe('CardView', () => {
 
       return view.initialize().then(() => {
         hostedFieldsConfiguredFields = hostedFields.create.mock.calls[0][0].fields;
+
         expect(hostedFieldsConfiguredFields.number.placeholder).toBe('•••• •••• •••• ••••');
         expect(hostedFieldsConfiguredFields.expirationDate.placeholder).toBe(strings.expirationDatePlaceholder);
         expect(hostedFieldsConfiguredFields.cvv.placeholder).toBe('•••');
@@ -755,7 +756,7 @@ describe('CardView', () => {
       });
     });
 
-    test.only('does not set aria-required attribute on hosted field if it is not rendered', () => {
+    test('does not set aria-required attribute on hosted field if it is not rendered', () => {
       fakeClient.getConfiguration.mockReturnValue({
         gatewayConfiguration: {
           challenges: [],

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -71,6 +71,61 @@ describe('CardView', () => {
       return fakeModel.initialize();
     });
 
+    test('sets aria-required attribute on hosted fields', () => {
+      fakeClient.getConfiguration.mockReturnValue({
+        gatewayConfiguration: {
+          challenges: ['cvv', 'postal_code'],
+          creditCards: {
+            supportedCardTypes: []
+          }
+        }
+      });
+
+      fakeModel.merchantConfiguration.card = {
+        cardholderName: true
+      };
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      return view.initialize().then(() => {
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'number', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'expirationDate', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cvv', attribute: 'aria-required', value: true });
+      });
+    });
+
+    test('does not set aria-required attribute on hosted field if it is not rendered', () => {
+      fakeClient.getConfiguration.mockReturnValue({
+        gatewayConfiguration: {
+          challenges: [],
+          creditCards: {
+            supportedCardTypes: []
+          }
+        }
+      });
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      return view.initialize().then(() => {
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalled();
+        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cvv', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
+      });
+    });
+
     test('defaults merchant configuration when not configured with a card configuration', () => {
       delete fakeModel.merchantConfiguration.card;
       const view = new CardView({
@@ -723,61 +778,6 @@ describe('CardView', () => {
         expect(hostedFieldsConfiguredFields.expirationDate.placeholder).toBe(strings.expirationDatePlaceholder);
         expect(hostedFieldsConfiguredFields.cvv.placeholder).toBe('•••');
         expect(hostedFieldsConfiguredFields.postalCode.placeholder).toBeFalsy();
-      });
-    });
-
-    test('sets aria-required attribute on hosted fields', () => {
-      fakeClient.getConfiguration.mockReturnValue({
-        gatewayConfiguration: {
-          challenges: ['cvv', 'postal_code'],
-          creditCards: {
-            supportedCardTypes: []
-          }
-        }
-      });
-
-      fakeModel.merchantConfiguration.card = {
-        cardholderName: true
-      };
-
-      const view = new CardView({
-        element: cardElement,
-        model: fakeModel,
-        client: fakeClient,
-        strings: strings
-      });
-
-      return view.initialize().then(() => {
-        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cvv', attribute: 'aria-required', value: true });
-        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'number', attribute: 'aria-required', value: true });
-        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'expirationDate', attribute: 'aria-required', value: true });
-        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
-        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
-      });
-    });
-
-    test('does not set aria-required attribute on hosted field if it is not rendered', () => {
-      fakeClient.getConfiguration.mockReturnValue({
-        gatewayConfiguration: {
-          challenges: [],
-          creditCards: {
-            supportedCardTypes: []
-          }
-        }
-      });
-
-      const view = new CardView({
-        element: cardElement,
-        model: fakeModel,
-        client: fakeClient,
-        strings: strings
-      });
-
-      return view.initialize().then(() => {
-        expect(fakeHostedFieldsInstance.setAttribute).toBeCalled();
-        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cvv', attribute: 'aria-required', value: true });
-        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
-        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
       });
     });
 

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -718,11 +718,36 @@ describe('CardView', () => {
 
       return view.initialize().then(() => {
         hostedFieldsConfiguredFields = hostedFields.create.mock.calls[0][0].fields;
-
         expect(hostedFieldsConfiguredFields.number.placeholder).toBe('•••• •••• •••• ••••');
         expect(hostedFieldsConfiguredFields.expirationDate.placeholder).toBe(strings.expirationDatePlaceholder);
         expect(hostedFieldsConfiguredFields.cvv.placeholder).toBe('•••');
         expect(hostedFieldsConfiguredFields.postalCode.placeholder).toBeFalsy();
+      });
+    });
+
+    test.only('sets aria-required attribute on hosted fields', () => {
+      fakeClient.getConfiguration.mockReturnValue({
+        gatewayConfiguration: {
+          challenges: ['cvv', 'postal_code'],
+          creditCards: {
+            supportedCardTypes: []
+          }
+        }
+      });
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      return view.initialize().then(() => {
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cvv', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'number', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'expirationDate', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
       });
     });
 
@@ -1717,7 +1742,7 @@ describe('CardView', () => {
           });
 
           return cardView.initialize().then(() => {
-            expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalled();
+            expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cvv', attribute: 'placeholder', value: '•••' });
           });
         }
       );
@@ -1738,7 +1763,7 @@ describe('CardView', () => {
           };
 
           return cardView.initialize().then(() => {
-            expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalled();
+            expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ attribute: 'placeholder', field: 'cvv', value: '•••' });
           });
         }
       );
@@ -1762,7 +1787,8 @@ describe('CardView', () => {
           };
 
           return cardView.initialize().then(() => {
-            expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalled();
+            expect(fakeHostedFieldsInstance.setAttribute).toBeCalled();
+            expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cvv' });
           });
         }
       );
@@ -2911,7 +2937,11 @@ describe('CardView', () => {
 
           cardView.showFieldError('foo', 'errorMessage');
 
-          expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalled();
+          expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({
+            field: 'foo',
+            attribute: 'aria-invalid',
+            value: true
+          });
         }
       );
     });

--- a/test/unit/views/payment-sheet-views/card-view.js
+++ b/test/unit/views/payment-sheet-views/card-view.js
@@ -735,6 +735,10 @@ describe('CardView', () => {
         }
       });
 
+      fakeModel.merchantConfiguration.card = {
+        cardholderName: true
+      };
+
       const view = new CardView({
         element: cardElement,
         model: fakeModel,
@@ -748,6 +752,31 @@ describe('CardView', () => {
         expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'expirationDate', attribute: 'aria-required', value: true });
         expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
         expect(fakeHostedFieldsInstance.setAttribute).toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
+      });
+    });
+
+    test.only('does not set aria-required attribute on hosted field if it is not rendered', () => {
+      fakeClient.getConfiguration.mockReturnValue({
+        gatewayConfiguration: {
+          challenges: [],
+          creditCards: {
+            supportedCardTypes: []
+          }
+        }
+      });
+
+      const view = new CardView({
+        element: cardElement,
+        model: fakeModel,
+        client: fakeClient,
+        strings: strings
+      });
+
+      return view.initialize().then(() => {
+        expect(fakeHostedFieldsInstance.setAttribute).toBeCalled();
+        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cvv', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'postalCode', attribute: 'aria-required', value: true });
+        expect(fakeHostedFieldsInstance.setAttribute).not.toBeCalledWith({ field: 'cardholderName', attribute: 'aria-required', value: true });
       });
     });
 


### PR DESCRIPTION
### Summary

Adds the `aria-hidden` label to the generic card icon in the upper left corner of the cardview so that screenreaders do not read it. Also, adds the `aria-required` label to the input in the hosted fields so screen readers can accurately indicate it is a required field.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
