### PR TITLE
Emit paymentMethodRequestable event after 3DS Challenge is completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   - Apple Pay
     - add error message prompting the customer to click the Apple Pay button when `requestPaymentMethod` is called.
   - 3D Secure
-    - Fix issue where `paymentMethodRequestable` event would fire before 3DS challenge has been completed.
+    - Fix issue where `paymentMethodRequestable` event would fire before 3DS challenge has been completed. (closes [#805](https://github.com/braintree/braintree-web-drop-in/issues/805))
 
 ## 1.41.0
   - Update braintree-web to 3.97.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
 ## UNRELEASED
-  - Apple Pay: add error message prompting the customer to click the Apple Pay button when `requestPaymentMethod` is called.
+  - Apple Pay
+    - add error message prompting the customer to click the Apple Pay button when `requestPaymentMethod` is called.
+  - 3D Secure
+    - Fix issue where `paymentMethodRequestable` event would fire before 3DS challenge has been completed.
 
 ## 1.41.0
   - Update braintree-web to 3.97.4

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -52,6 +52,7 @@ function DropinModel(options) {
   this.failedDependencies = {};
   this._options = options;
   this._setupComplete = false;
+  this._shouldWaitForVerifyCard = false;
 
   while (this.rootNode.parentNode) {
     this.rootNode = this.rootNode.parentNode;
@@ -96,6 +97,10 @@ DropinModel.prototype.initialize = function () {
 
 DropinModel.prototype.confirmDropinReady = function () {
   this._setupComplete = true;
+};
+
+DropinModel.prototype.verifyCardReady = function () {
+  this._shouldWaitForVerifyCard = !this._shouldWaitForVerifyCard;
 };
 
 DropinModel.prototype.isPaymentMethodRequestable = function () {
@@ -220,6 +225,10 @@ DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
     // fixes issues with lazy loading of imports where event
     // should not be emitted
     // https://github.com/braintree/braintree-web-drop-in/issues/511
+    return false;
+  }
+
+  if (this._shouldWaitForVerifyCard) {
     return false;
   }
 

--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -52,7 +52,7 @@ function DropinModel(options) {
   this.failedDependencies = {};
   this._options = options;
   this._setupComplete = false;
-  this._shouldWaitForVerifyCard = false;
+  this.shouldWaitForVerifyCard = false;
 
   while (this.rootNode.parentNode) {
     this.rootNode = this.rootNode.parentNode;
@@ -97,10 +97,6 @@ DropinModel.prototype.initialize = function () {
 
 DropinModel.prototype.confirmDropinReady = function () {
   this._setupComplete = true;
-};
-
-DropinModel.prototype.verifyCardReady = function () {
-  this._shouldWaitForVerifyCard = !this._shouldWaitForVerifyCard;
 };
 
 DropinModel.prototype.isPaymentMethodRequestable = function () {
@@ -228,7 +224,7 @@ DropinModel.prototype._shouldEmitRequestableEvent = function (options) {
     return false;
   }
 
-  if (this._shouldWaitForVerifyCard) {
+  if (this.shouldWaitForVerifyCard) {
     return false;
   }
 

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -876,7 +876,7 @@ Dropin.prototype.requestPaymentMethod = function (options) {
       self._mainView.showLoadingIndicator();
 
       return self._threeDSecure.verify(payload, options.threeDSecure).then(function (newPayload) {
-        self._model.verifyCardReady();
+        self._model.shouldWaitForVerifyCard = false;
         payload.nonce = newPayload.nonce;
         payload.liabilityShifted = newPayload.liabilityShifted;
         payload.liabilityShiftPossible = newPayload.liabilityShiftPossible;

--- a/src/dropin.js
+++ b/src/dropin.js
@@ -876,10 +876,16 @@ Dropin.prototype.requestPaymentMethod = function (options) {
       self._mainView.showLoadingIndicator();
 
       return self._threeDSecure.verify(payload, options.threeDSecure).then(function (newPayload) {
+        self._model.verifyCardReady();
         payload.nonce = newPayload.nonce;
         payload.liabilityShifted = newPayload.liabilityShifted;
         payload.liabilityShiftPossible = newPayload.liabilityShiftPossible;
         payload.threeDSecureInfo = newPayload.threeDSecureInfo;
+        self._model.setPaymentMethodRequestable({
+          isRequestable: Boolean(newPayload),
+          type: newPayload.type,
+          selectedPaymentMethod: payload
+        });
 
         self._mainView.hideLoadingIndicator();
 

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -39,8 +39,6 @@ ThreeDSecure.prototype.initialize = function () {
 };
 
 ThreeDSecure.prototype.verify = function (payload, merchantProvidedData) {
-  var self = this;
-
   var verifyOptions = assign({
     amount: this._config.amount
   }, merchantProvidedData, {
@@ -56,7 +54,7 @@ ThreeDSecure.prototype.verify = function (payload, merchantProvidedData) {
 
   verifyOptions.additionalInformation = verifyOptions.additionalInformation || {};
   verifyOptions.additionalInformation.acsWindowSize = verifyOptions.additionalInformation.acsWindowSize || DEFAULT_ACS_WINDOW_SIZE;
-  self._model.verifyCardReady();
+  this._model.verifyCardReady();
 
   return this._instance.verifyCard(verifyOptions);
 };

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -39,6 +39,8 @@ ThreeDSecure.prototype.initialize = function () {
 };
 
 ThreeDSecure.prototype.verify = function (payload, merchantProvidedData) {
+  var self = this;
+
   var verifyOptions = assign({
     amount: this._config.amount
   }, merchantProvidedData, {
@@ -54,6 +56,7 @@ ThreeDSecure.prototype.verify = function (payload, merchantProvidedData) {
 
   verifyOptions.additionalInformation = verifyOptions.additionalInformation || {};
   verifyOptions.additionalInformation.acsWindowSize = verifyOptions.additionalInformation.acsWindowSize || DEFAULT_ACS_WINDOW_SIZE;
+  self._model.verifyCardReady();
 
   return this._instance.verifyCard(verifyOptions);
 };

--- a/src/lib/three-d-secure.js
+++ b/src/lib/three-d-secure.js
@@ -54,7 +54,7 @@ ThreeDSecure.prototype.verify = function (payload, merchantProvidedData) {
 
   verifyOptions.additionalInformation = verifyOptions.additionalInformation || {};
   verifyOptions.additionalInformation.acsWindowSize = verifyOptions.additionalInformation.acsWindowSize || DEFAULT_ACS_WINDOW_SIZE;
-  this._model.verifyCardReady();
+  this._model.shouldWaitForVerifyCard = true;
 
   return this._instance.verifyCard(verifyOptions);
 };

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -208,6 +208,22 @@ describe('DropinModel', () => {
     });
   });
 
+  describe('verifyCardReady', () => {
+    test('toggles _shouldWaitForVerifyCard from true to false', () => {
+      const model = new DropinModel(testContext.modelOptions);
+
+      expect(model._shouldWaitForVerifyCard).toBe(false);
+
+      model.verifyCardReady();
+
+      expect(model._shouldWaitForVerifyCard).toBe(true);
+
+      model.verifyCardReady();
+
+      expect(model._shouldWaitForVerifyCard).toBe(false);
+    });
+  });
+
   describe('initialize', () => {
     test('emits asyncDependenciesReady event when no dependencies are set to initializing', (done) => {
       jest.useFakeTimers();

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -1101,6 +1101,31 @@ describe('DropinModel', () => {
     );
 
     test(
+      'does not emit paymentMethodRequestable event until after three D secure verification has been completed',
+      () => {
+        testContext.model._shouldWaitForVerifyCard = true;
+        testContext.model.setPaymentMethodRequestable({
+          isRequestable: true,
+          type: 'card'
+        });
+
+        expect(testContext.model._emit).not.toBeCalled();
+
+        testContext.model._shouldWaitForVerifyCard = false;
+
+        testContext.model.setPaymentMethodRequestable({
+          isRequestable: true,
+          type: 'card',
+          selectedPaymentMethod: {
+            nonce: 'fake-nonce'
+          }
+        });
+
+        expect(testContext.model._emit).toBeCalled();
+      }
+    );
+
+    test(
       'sets isPaymentMethodRequestable to false when isRequestable is false',
       () => {
         testContext.model._paymentMethodIsRequestable = true;

--- a/test/unit/dropin-model.js
+++ b/test/unit/dropin-model.js
@@ -208,22 +208,6 @@ describe('DropinModel', () => {
     });
   });
 
-  describe('verifyCardReady', () => {
-    test('toggles _shouldWaitForVerifyCard from true to false', () => {
-      const model = new DropinModel(testContext.modelOptions);
-
-      expect(model._shouldWaitForVerifyCard).toBe(false);
-
-      model.verifyCardReady();
-
-      expect(model._shouldWaitForVerifyCard).toBe(true);
-
-      model.verifyCardReady();
-
-      expect(model._shouldWaitForVerifyCard).toBe(false);
-    });
-  });
-
   describe('initialize', () => {
     test('emits asyncDependenciesReady event when no dependencies are set to initializing', (done) => {
       jest.useFakeTimers();
@@ -1103,7 +1087,7 @@ describe('DropinModel', () => {
     test(
       'does not emit paymentMethodRequestable event until after three D secure verification has been completed',
       () => {
-        testContext.model._shouldWaitForVerifyCard = true;
+        testContext.model.shouldWaitForVerifyCard = true;
         testContext.model.setPaymentMethodRequestable({
           isRequestable: true,
           type: 'card'
@@ -1111,7 +1095,7 @@ describe('DropinModel', () => {
 
         expect(testContext.model._emit).not.toBeCalled();
 
-        testContext.model._shouldWaitForVerifyCard = false;
+        testContext.model.shouldWaitForVerifyCard = false;
 
         testContext.model.setPaymentMethodRequestable({
           isRequestable: true,

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1212,7 +1212,7 @@ describe('Dropin', () => {
       }
     );
 
-    test('calls verifyCardReady and setPaymentMethodRequestable when 3D secure is complete', done => {
+    test('sets shouldWaitForVerifyCard to false and calls setPaymentMethodRequestable when 3D secure is complete', done => {
       let instance;
       const fakePayload = {
         nonce: 'cool-nonce',
@@ -1231,14 +1231,13 @@ describe('Dropin', () => {
 
       instance._initialize(() => {
         jest.spyOn(instance._mainView, 'requestPaymentMethod').mockResolvedValue(fakePayload);
-        jest.spyOn(instance._model, 'verifyCardReady').mockResolvedValue();
         jest.spyOn(instance._model, 'setPaymentMethodRequestable').mockResolvedValue();
         instance._threeDSecure = {
           verify: jest.fn().mockResolvedValue(fakeNewPayload)
         };
 
         instance.requestPaymentMethod(() => {
-          expect(instance._model.verifyCardReady).toBeCalled();
+          expect(instance._model.shouldWaitForVerifyCard).toBe(false);
           expect(instance._model.setPaymentMethodRequestable).toBeCalledWith({
             isRequestable: true,
             type: fakeNewPayload.type,

--- a/test/unit/dropin.js
+++ b/test/unit/dropin.js
@@ -1212,7 +1212,7 @@ describe('Dropin', () => {
       }
     );
 
-    test('calls verifyCardReady and setPaymentMethodRequestable when 3D secure is called', done => {
+    test('calls verifyCardReady and setPaymentMethodRequestable when 3D secure is complete', done => {
       let instance;
       const fakePayload = {
         nonce: 'cool-nonce',

--- a/test/unit/lib/three-d-secure.js
+++ b/test/unit/lib/three-d-secure.js
@@ -119,8 +119,8 @@ describe('ThreeDSecure', () => {
       });
     });
 
-    test('calls verifyCardReady', () => {
-      jest.spyOn(testContext.model, 'verifyCardReady').mockResolvedValue();
+    test('sets shouldWaitForVerifyCard to true', () => {
+      expect(testContext.model.shouldWaitForVerifyCard).toBe(false);
 
       return testContext.tds.verify({
         nonce: 'old-nonce',
@@ -128,7 +128,7 @@ describe('ThreeDSecure', () => {
           bin: '123456'
         }
       }).then(() => {
-        expect(testContext.model.verifyCardReady).toBeCalled();
+        expect(testContext.model.shouldWaitForVerifyCard).toBe(true);
       });
     });
 

--- a/test/unit/lib/three-d-secure.js
+++ b/test/unit/lib/three-d-secure.js
@@ -119,6 +119,19 @@ describe('ThreeDSecure', () => {
       });
     });
 
+    test('calls verifyCardReady', () => {
+      jest.spyOn(testContext.model, 'verifyCardReady').mockResolvedValue();
+
+      return testContext.tds.verify({
+        nonce: 'old-nonce',
+        details: {
+          bin: '123456'
+        }
+      }).then(() => {
+        expect(testContext.model.verifyCardReady).toBeCalled();
+      });
+    });
+
     test('rejects if verifyCard rejects', () => {
       testContext.threeDSecureInstance.verifyCard.mockRejectedValue({
         message: 'A message'


### PR DESCRIPTION
### Summary

[Jira](https://paypal.atlassian.net/browse/LI-29388)

Holds off sending the [`paymentMethodRequestable`](https://braintree.github.io/braintree-web-drop-in/docs/current/Dropin.html#event:paymentMethodRequestable) event until after `verifyCard` has completed for 3DS flows.

Addresses #805 

Testing strategy:

Run the [Drop-in demo in development mode](https://github.com/braintree/braintree-web-drop-in/blob/main/DEVELOPMENT.md#demo-app-and-jsdocs) and add the following query parameters to the URL in your browser:

`?threeDSecure=true&authorization=<generate-a-client-token>`

Then test [each test card listed in our 3DS documentation](https://developer.paypal.com/braintree/docs/guides/3d-secure/testing-go-live/ruby) to make sure everything works as expected on each flow. Open the dev console and notice that the event does not fire off until 3DS authentication is completed:

`paymentMethodRequestable {paymentMethodIsSelected: true, type: 'CreditCard'}`

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
