### PR TITLE
Update braintree-web dependency to 3.101.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## UNRELEASED
-  - Update braintree-web to 3.100.0
+  - Update braintree-web to 3.101.0
 
 ## 1.42.0
   - Apple Pay

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "0.1.0",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.100.0"
+    "braintree-web": "3.101.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
### Summary

Updated `braintree/braintree-web` dependency to 3.101.0.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @ibooker 
