### PR TITLE
Update braintree-web version to 3.112.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.44.0
+  - Update Braintree web dependancies
+    - braintree-web to 3.112.0
+
 ## 1.43.0
   - Update Braintree web dependancies
     - asset-loader to 2.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-web-drop-in",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1455,6 +1455,23 @@
         "fastq": "^1.6.0"
       }
     },
+    "@paypal/accelerated-checkout-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@paypal/accelerated-checkout-loader/-/accelerated-checkout-loader-1.1.0.tgz",
+      "integrity": "sha512-S2KkIpq15VnxYyI0tycvfYiNsqdsg2a92El2huYUVLsWnBbubl8toYK8khaP5nnxZ0MGl9mEB9Y9axmfOw2Yvg==",
+      "requires": {
+        "@braintree/asset-loader": "2.0.0",
+        "envify": "^4.1.0",
+        "typescript": "^4.6.4"
+      },
+      "dependencies": {
+        "@braintree/asset-loader": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@braintree/asset-loader/-/asset-loader-2.0.0.tgz",
+          "integrity": "sha512-7Zs3/g3lPTfkdtWr7cKh3tk1pDruXR++TXwGKkx7BPuTjjLNFul2JSfI+ScHzNU4u/gZNPNQagsSTlYxIhBgMA=="
+        }
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -2871,9 +2888,9 @@
       }
     },
     "braintree-web": {
-      "version": "3.103.0",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.103.0.tgz",
-      "integrity": "sha512-gwmC5LSUP5VUC2HmUyaFnEyLjRRAo1iKKHS5eD9KIAZHB7cAQ2il1V1q2f5zdz7+7EE11eSHXznj6n/Qm6jp6w==",
+      "version": "3.112.0",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.112.0.tgz",
+      "integrity": "sha512-aRO85k34U86hdztUb3shwUPjT30xeuJ0s/+/v8ye1LcBxFUJ9iJzupPTKkN6wcm8mAAkFRBfOE4389hIE17Xdg==",
       "requires": {
         "@braintree/asset-loader": "2.0.1",
         "@braintree/browser-detection": "2.0.1",
@@ -2883,6 +2900,7 @@
         "@braintree/sanitize-url": "7.0.4",
         "@braintree/uuid": "1.0.0",
         "@braintree/wrap-promise": "2.1.0",
+        "@paypal/accelerated-checkout-loader": "1.1.0",
         "card-validator": "10.0.0",
         "credit-card-type": "10.0.1",
         "framebus": "6.0.0",
@@ -4665,6 +4683,15 @@
         "once": "^1.4.0"
       }
     },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
+      }
+    },
     "errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -5087,8 +5114,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -13239,8 +13265,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "4.0.2",
@@ -13467,6 +13492,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "ua-parser-js": {
       "version": "1.0.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-web-drop-in",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "main": "src/index.js",
   "private": true,
   "scripts": {
@@ -69,7 +69,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "1.0.0",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.103.0"
+    "braintree-web": "3.112.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
### Summary

Update drop-in to braintree-web 3.112.0

<!-- NOTE: We cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. 

If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team. 

You may provide your own custom translations by using the `translations` paramter when creating the Drop-in instance: https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create
-->

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
