### PR TITLE
Update en_US.js

### DIFF
--- a/src/translations/en_US.js
+++ b/src/translations/en_US.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  payingWith: 'Paying with {{paymentSource}}',
+  payingWith: 'Pay with {{paymentSource}}',
   chooseAnotherWayToPay: 'Choose another way to pay',
   chooseAWayToPay: 'Choose a way to pay',
   otherWaysToPay: 'Other ways to pay',


### PR DESCRIPTION
Label has changed for "payingWith".

### Summary

<!-- NOTE: We cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. 

If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team. 

You may provide your own custom translations by using the `translations` paramter when creating the Drop-in instance: https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create
-->

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
