### PR TITLE
Add Error Message to Last Hosted Field If User Tabs to the Paypal Collection Notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## UNRELEASED
+  - Fix bug where the last card field would not display a message if the user tabbed to the Paypal Collection notice
+
 ## 1.44.0
   - Update Braintree web dependency
     - braintree-web to 3.113.0

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -665,6 +665,11 @@ function hideCardIcon(icon) {
 function isCardViewElement() {
   var activeId = document.activeElement && document.activeElement.id;
   var isHostedFieldsElement = document.activeElement instanceof HTMLIFrameElement && activeId.indexOf('braintree-hosted-field') !== -1;
+  var isPaypalCollectionNotice = document.activeElement.parentElement.className === 'braintree-form__notice-of-collection';
+
+  if (isPaypalCollectionNotice) {
+    return true;
+  }
 
   return isHostedFieldsElement;
 }

--- a/src/views/payment-sheet-views/card-view.js
+++ b/src/views/payment-sheet-views/card-view.js
@@ -665,7 +665,7 @@ function hideCardIcon(icon) {
 function isCardViewElement() {
   var activeId = document.activeElement && document.activeElement.id;
   var isHostedFieldsElement = document.activeElement instanceof HTMLIFrameElement && activeId.indexOf('braintree-hosted-field') !== -1;
-  var isPaypalCollectionNotice = document.activeElement.parentElement.className === 'braintree-form__notice-of-collection';
+  var isPaypalCollectionNotice = document.activeElement && document.activeElement.parentElement.className === 'braintree-form__notice-of-collection';
 
   if (isPaypalCollectionNotice) {
     return true;


### PR DESCRIPTION
### Summary

If a user tabs to the paypal collection notice, the error message is not displayed when expected

Before

https://github.com/user-attachments/assets/1cd5e92a-d6a5-438b-9a2d-7f7d77c76cba

After

https://github.com/user-attachments/assets/344c165d-dce0-4bdc-886b-94f31688555b



### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jplukarski 
