### PR TITLE
Update braintree-web dependency - 3.117.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "1.0.1",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.115.1"
+    "braintree-web": "3.117.1"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
### Summary

Update `braintree-web` dependency to 3.117.1.

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @ibooker 
