### PR TITLE
Upgrade braintree-web to 3.123.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## UNRELEASED
+
+- Update dependencies
+  - braintree-web to 3.123.2
+
 ## 1.45.0
   - Fix bug where field would be incorrectly presented as invalid while using autocomplete
   - Update Braintree web dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@braintree/event-emitter": "0.4.1",
         "@braintree/uuid": "1.0.1",
         "@braintree/wrap-promise": "2.1.0",
-        "braintree-web": "3.122.0"
+        "braintree-web": "3.123.2"
       },
       "devDependencies": {
         "@wdio/browserstack-service": "^7.25.2",
@@ -3534,9 +3534,9 @@
       }
     },
     "node_modules/braintree-web": {
-      "version": "3.122.0",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.122.0.tgz",
-      "integrity": "sha512-zyZIYK72ZEyorlSO39L5ebvXz9tquJw5JqMbPbNcgjGayGgesoC6xCuh5uSaCmTxko597YEpURV5dgDfO3PjOQ==",
+      "version": "3.123.2",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.123.2.tgz",
+      "integrity": "sha512-N4IH75vKY67eONc0Ao4e7F+XagFW+3ok+Nfs/eOjw5D/TUt03diMAQ8woOwJghi2ql6/yjqNzZi2zE/sTWXmJg==",
       "dependencies": {
         "@braintree/asset-loader": "2.0.3",
         "@braintree/browser-detection": "2.0.2",
@@ -3547,7 +3547,7 @@
         "@braintree/uuid": "1.0.1",
         "@braintree/wrap-promise": "2.1.0",
         "@paypal/accelerated-checkout-loader": "1.1.0",
-        "card-validator": "10.0.2",
+        "card-validator": "10.0.3",
         "credit-card-type": "10.0.2",
         "framebus": "6.0.3",
         "inject-stylesheet": "6.0.2",
@@ -4210,9 +4210,9 @@
       ]
     },
     "node_modules/card-validator": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-10.0.2.tgz",
-      "integrity": "sha512-Mq8puzE9LqVoKK83Vpcl7x4CF2brHk/1ufYQWvVVpedGc/wXt844oWzwAkBbnbRdYQKwfBkfoWtR7vRvnIbf2g==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-10.0.3.tgz",
+      "integrity": "sha512-xOEDsK3hojV0OIpmrR64eZGpngnOqRDEP20O+WSRtvjLSW6nyekW4i2N9SzYg679uFO3RyHcFHxb+mml5tXc4A==",
       "dependencies": {
         "credit-card-type": "^10.0.2"
       }
@@ -21123,9 +21123,9 @@
       }
     },
     "braintree-web": {
-      "version": "3.122.0",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.122.0.tgz",
-      "integrity": "sha512-zyZIYK72ZEyorlSO39L5ebvXz9tquJw5JqMbPbNcgjGayGgesoC6xCuh5uSaCmTxko597YEpURV5dgDfO3PjOQ==",
+      "version": "3.123.2",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.123.2.tgz",
+      "integrity": "sha512-N4IH75vKY67eONc0Ao4e7F+XagFW+3ok+Nfs/eOjw5D/TUt03diMAQ8woOwJghi2ql6/yjqNzZi2zE/sTWXmJg==",
       "requires": {
         "@braintree/asset-loader": "2.0.3",
         "@braintree/browser-detection": "2.0.2",
@@ -21136,7 +21136,7 @@
         "@braintree/uuid": "1.0.1",
         "@braintree/wrap-promise": "2.1.0",
         "@paypal/accelerated-checkout-loader": "1.1.0",
-        "card-validator": "10.0.2",
+        "card-validator": "10.0.3",
         "credit-card-type": "10.0.2",
         "framebus": "6.0.3",
         "inject-stylesheet": "6.0.2",
@@ -21683,9 +21683,9 @@
       "dev": true
     },
     "card-validator": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-10.0.2.tgz",
-      "integrity": "sha512-Mq8puzE9LqVoKK83Vpcl7x4CF2brHk/1ufYQWvVVpedGc/wXt844oWzwAkBbnbRdYQKwfBkfoWtR7vRvnIbf2g==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-10.0.3.tgz",
+      "integrity": "sha512-xOEDsK3hojV0OIpmrR64eZGpngnOqRDEP20O+WSRtvjLSW6nyekW4i2N9SzYg679uFO3RyHcFHxb+mml5tXc4A==",
       "requires": {
         "credit-card-type": "^10.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@braintree/event-emitter": "0.4.1",
     "@braintree/uuid": "1.0.1",
     "@braintree/wrap-promise": "2.1.0",
-    "braintree-web": "3.122.0"
+    "braintree-web": "3.123.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
### Summary
Upgrade braintree-web to 3.123.2

<!-- NOTE: We cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. 

If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team. 

You may provide your own custom translations by using the `translations` paramter when creating the Drop-in instance: https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#.create
-->

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @codentacos 
